### PR TITLE
Add secrets scanning (Gitleaks), policy engine, and secrets UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,9 +2,15 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Rules
+
+ALWAYS update CLAUDE.md before pushing any code to GitHub
+ALWAYS create a new branch before starting any new work
+ALWAYS push the branch to GitHub and open a PR
+
 ## What This Is
 
-Snitch is an AppSec platform that aggregates security findings from Semgrep (SAST), Grype (container CVEs), and Trivy (SCA), calculates per-app risk scores, and provides AI-powered remediation via Anthropic Claude.
+Snitch is an AppSec platform that aggregates security findings from Semgrep (SAST), Grype (container CVEs), Trivy (SCA), and Gitleaks (secrets), calculates per-app risk scores, and provides AI-powered remediation via Anthropic Claude.
 
 ## Commands
 
@@ -42,14 +48,18 @@ backend/app/
 ├── main.py          # FastAPI app, CORS, static mount, lifespan (creates tables on startup)
 ├── core/config.py   # pydantic-settings: DATABASE_URL, GITHUB_TOKEN, ANTHROPIC_API_KEY, REDIS_URL
 ├── db/session.py    # async SQLAlchemy engine + get_db() dependency
-├── models/          # SQLAlchemy ORM: Application, Scan, Finding, Remediation
+├── models/          # SQLAlchemy ORM: Application, Scan, Finding, Remediation, CiCdScan, Policy, SecretPattern
 ├── schemas/         # Pydantic request/response schemas (mirrors models/)
 ├── api/v1/          # Route handlers; all mounted under /api/v1/ via router.py
-├── worker/          # Celery task definitions (scans, periodic jobs)
+│   │                # includes: applications, findings, scans, remediation, reports,
+│   │                #           cicd_scans, policies, secrets, github, seed
+├── worker/          # Celery task definitions (scans, periodic jobs, SQS polling)
 └── services/
-    ├── scanner.py         # Mock Semgrep/Grype/Trivy scanner (returns fake findings)
+    ├── scanner.py         # Semgrep/Trivy/Govulncheck/Gitleaks + MockScannerService
     ├── scoring.py         # Risk score calculator
-    ├── deduplication.py   # Finding deduplication logic
+    ├── deduplication.py   # Finding deduplication logic (SAST/SCA/secrets/generic keys)
+    ├── cicd_normaliser.py # Normalise Semgrep/Grype CI/CD JSON output
+    ├── policy_evaluator.py # Evaluate policy rules against findings
     ├── ai_remediation.py  # Claude integration; falls back to mock plan if no API key
     └── github_service.py  # GitHub code scanning sync + branch/PR creation via PyGitHub
 ```
@@ -73,8 +83,14 @@ backend/app/
 ### Finding Fields
 - `severity`: `critical` / `high` / `medium` / `low` / `info`
 - `status`: `open` / `fixed` / `accepted` / `false_positive`
-- `finding_type`: `SAST` / `SCA` / `container`
-- `scanner`: `semgrep` / `grype` / `trivy`
+- `finding_type`: `SAST` / `SCA` / `container` / `secrets`
+- `scanner`: `semgrep` / `grype` / `trivy` / `govulncheck` / `gitleaks`
+
+### Secrets Scanning
+Gitleaks runs alongside Semgrep/Trivy in `scan_application_task`. Active `SecretPattern` rows are loaded from the DB at scan time and written to a temp TOML config passed to gitleaks via `--config`. Raw secret values are never stored — masked to `****{last4}` in the `description` field. Dedup key: `("secrets", rule_id, file_path)`.
+
+### Policy Engine
+`Policy` model stores rules (min_severity, enabled_scan_types, rule_blocklist, rule_allowlist, action). `policy_evaluator.evaluate_policy()` is called after every scan in `scan_application_task`. Actions: `inform` (log only) or `block` (sets blocked=True in task result).
 
 ### AI Remediation
 Uses `claude-3-5-sonnet-20241022` with extended thinking (`budget_tokens=10000`). When `ANTHROPIC_API_KEY` is not set, `_mock_plan()` is returned — no error is raised. The Anthropic client is imported lazily inside the function.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Powered by Claude](https://img.shields.io/badge/AI-Claude%203.5%20Sonnet-orange.svg?logo=anthropic)](https://www.anthropic.com/)
 [![GitHub Issues](https://img.shields.io/github/issues/andrewblooman/snitch)](https://github.com/andrewblooman/snitch/issues)
 
-> **Snitch** is a developer-focused AppSec platform that collects security findings from Semgrep (SAST), Grype (container scanning), and Trivy (SCA), calculates per-application risk scores, and provides AI-powered remediation via Anthropic Claude.
+> **Snitch** is a developer-focused AppSec platform that collects security findings from Semgrep (SAST), Grype (container scanning), Trivy (SCA), and Gitleaks (secrets), calculates per-application risk scores, and provides AI-powered remediation via Anthropic Claude.
 
 ![Dashboard](https://github.com/user-attachments/assets/36512a1b-3b76-41cc-af98-0ad688ce1784)
 
@@ -18,10 +18,12 @@
 | Feature | Description |
 |---|---|
 | 📊 **Risk Scoring** | Automatic risk score (0–100) per app derived from open findings by severity |
-| 🔍 **Multi-Scanner** | Semgrep (SAST), Grype (container CVEs), Trivy (SCA/OS vulnerabilities) |
+| 🔍 **Multi-Scanner** | Semgrep (SAST), Grype (container CVEs), Trivy (SCA/OS vulnerabilities), Gitleaks (secrets) |
+| 🔑 **Secrets Detection** | Gitleaks integration with configurable custom regex patterns per organisation |
 | 🤖 **AI Remediation** | Claude-powered "Plan Remediation" generates fix instructions, then creates a GitHub PR |
 | 📈 **90-Day Trends** | Management reporting with vulnerability trends, team leaderboard, and MTTR |
 | 🔗 **GitHub Integration** | Sync code-scanning alerts from GitHub Security; auto-create branches & PRs |
+| 🚦 **Policy Engine** | Define pass/fail gates by severity, scan type, and rule — evaluated on every scan |
 | 🌐 **REST API** | Full OpenAPI/Swagger docs at `/docs` |
 
 ---
@@ -53,17 +55,16 @@ The platform will be available at **http://localhost:8000**
 - 🏠 Dashboard: http://localhost:8000/
 - 📱 Applications: http://localhost:8000/applications.html
 - 📊 Reports: http://localhost:8000/reports.html
+- 🔑 Secrets: http://localhost:8000/secrets.html
 - 📖 API Docs: http://localhost:8000/docs
 
-### 3. Seed demo data
-
-Click the **"Seed Demo Data"** button on the dashboard, or call the API directly:
+### 3. Seed demo data (optional)
 
 ```bash
 curl -X POST http://localhost:8000/api/v1/seed
 ```
 
-This creates 8 realistic demo applications with findings from Semgrep, Grype, and Trivy across 4 teams.
+Creates 8 realistic demo applications with findings from Semgrep, Grype, and Trivy across 4 teams.
 
 ---
 
@@ -76,7 +77,11 @@ snitch/
 │   │   ├── main.py             # FastAPI app, middleware, static mount
 │   │   ├── core/config.py      # Settings (pydantic-settings)
 │   │   ├── db/                 # SQLAlchemy async engine + session
-│   │   ├── models/             # ORM models (Application, Scan, Finding, Remediation)
+│   │   ├── models/             # ORM models
+│   │   │   ├── application.py, scan.py, finding.py, remediation.py
+│   │   │   ├── cicd_scan.py    # CI/CD scan ingestion records
+│   │   │   ├── policy.py       # Policy engine rules
+│   │   │   └── secret_pattern.py  # Custom Gitleaks regex patterns
 │   │   ├── schemas/            # Pydantic request/response schemas
 │   │   ├── api/v1/             # API route handlers
 │   │   │   ├── applications.py # CRUD + scan trigger + GitHub sync
@@ -84,23 +89,34 @@ snitch/
 │   │   │   ├── scans.py        # Scan history
 │   │   │   ├── remediation.py  # AI plan + PR execution
 │   │   │   ├── reports.py      # Overview, leaderboard, trend, top CVEs
+│   │   │   ├── cicd_scans.py   # CI/CD scan results (S3/SQS ingestion)
+│   │   │   ├── policies.py     # Policy CRUD + evaluation
+│   │   │   ├── secrets.py      # Secrets findings + custom pattern CRUD
 │   │   │   └── seed.py         # Demo data seeder
-│   │   └── services/
-│   │       ├── scanner.py      # Mock Semgrep/Grype/Trivy scanner
-│   │       ├── scoring.py      # Risk score calculator
-│   │       ├── ai_remediation.py  # Anthropic Claude integration
-│   │       └── github_service.py  # GitHub Security sync + PR creation
-│   ├── alembic/                # Database migrations
-│   ├── tests/                  # pytest test suite (20 tests)
+│   │   ├── services/
+│   │   │   ├── scanner.py      # Semgrep/Trivy/Govulncheck/Gitleaks scanners
+│   │   │   ├── scoring.py      # Risk score calculator
+│   │   │   ├── deduplication.py   # Finding upsert + dedup logic
+│   │   │   ├── cicd_normaliser.py # Normalise Semgrep/Grype CI output
+│   │   │   ├── policy_evaluator.py
+│   │   │   ├── ai_remediation.py  # Anthropic Claude integration
+│   │   │   └── github_service.py  # GitHub Security sync + PR creation
+│   │   └── worker/             # Celery async tasks
+│   │       ├── tasks.py        # scan_application_task, poll_sqs_task, weekly_scan_all
+│   │       └── celery_app.py
+│   ├── alembic/                # Database migrations (005 revisions)
+│   ├── tests/                  # pytest test suite
 │   ├── Dockerfile
 │   └── requirements.txt
-├── frontend/                   # Static HTML/CSS/JS dashboard
-│   ├── index.html              # Main dashboard
-│   ├── applications.html       # Application portfolio view
+├── frontend/                   # Static HTML/CSS/JS (no build step)
+│   ├── index.html              # Dashboard
+│   ├── applications.html       # Application portfolio
 │   ├── app-detail.html         # Per-app findings + remediation
 │   ├── reports.html            # Management reporting
-│   └── static/
-│       └── js/                 # Bundled Chart.js + Lucide icons
+│   ├── repositories.html       # GitHub repo browser
+│   ├── policies.html           # Policy engine UI
+│   ├── secrets.html            # Secrets findings + custom pattern manager
+│   └── static/js/              # Bundled Chart.js + Lucide icons
 ├── docker-compose.yml
 └── .env.example
 ```
@@ -113,23 +129,56 @@ All endpoints are documented via Swagger UI at `/docs` and ReDoc at `/redoc`.
 
 ### Core Endpoints
 
+Full interactive docs at `/docs` (Swagger UI) and `/redoc`.
+
+**Applications & Findings**
+
 | Method | Path | Description |
 |---|---|---|
 | `GET` | `/api/v1/applications` | List apps with risk scores (filterable by team, risk level) |
 | `POST` | `/api/v1/applications` | Register a new application |
 | `GET` | `/api/v1/applications/{id}` | Get app detail with finding summary |
-| `POST` | `/api/v1/applications/{id}/scan` | Trigger Semgrep/Grype/Trivy scan |
+| `POST` | `/api/v1/applications/{id}/scan` | Trigger Semgrep/Trivy/Gitleaks scan |
 | `GET` | `/api/v1/applications/{id}/findings` | Get findings (filterable by severity, type, status) |
 | `POST` | `/api/v1/applications/{id}/sync-github` | Sync from GitHub Security alerts |
 | `GET` | `/api/v1/findings` | List all findings across apps |
 | `PATCH` | `/api/v1/findings/{id}` | Update finding status (open/fixed/accepted/false_positive) |
+
+**Secrets**
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/v1/secrets/findings` | List secrets findings (filterable by app, severity, status) |
+| `GET` | `/api/v1/secrets/findings/stats` | Secrets counts by severity and rule |
+| `PATCH` | `/api/v1/secrets/findings/{id}` | Update secret finding status |
+| `GET` | `/api/v1/secrets/patterns` | List custom Gitleaks regex patterns |
+| `POST` | `/api/v1/secrets/patterns` | Create custom pattern |
+| `PUT` | `/api/v1/secrets/patterns/{id}` | Update pattern |
+| `DELETE` | `/api/v1/secrets/patterns/{id}` | Delete pattern |
+| `POST` | `/api/v1/secrets/patterns/test` | Test a regex against sample text |
+
+**Policies**
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/v1/policies` | List policies |
+| `POST` | `/api/v1/policies` | Create policy |
+| `PATCH` | `/api/v1/policies/{id}` | Update policy |
+| `DELETE` | `/api/v1/policies/{id}` | Delete policy |
+| `POST` | `/api/v1/policies/{id}/evaluate` | Evaluate policy against current findings |
+| `GET` | `/api/v1/policies/evaluate/all` | Evaluate all active policies |
+
+**Reports & CI/CD**
+
+| Method | Path | Description |
+|---|---|---|
 | `POST` | `/api/v1/remediation/plan` | Generate AI remediation plan for selected findings |
 | `POST` | `/api/v1/remediation/{id}/execute` | Execute plan: create branch + GitHub PR |
 | `GET` | `/api/v1/reports/overview` | Platform-wide stats |
 | `GET` | `/api/v1/reports/leaderboard` | Team security leaderboard |
 | `GET` | `/api/v1/reports/trend?days=90` | 90-day vulnerability trend |
-| `GET` | `/api/v1/reports/pull-requests` | All Snitch-created PRs |
 | `GET` | `/api/v1/reports/top-vulnerabilities` | Most common CVEs/rules |
+| `GET` | `/api/v1/cicd-scans` | List CI/CD scan results ingested via S3/SQS |
 | `POST` | `/api/v1/seed` | Seed demo data |
 
 ---

--- a/backend/alembic/versions/004_add_policies_table.py
+++ b/backend/alembic/versions/004_add_policies_table.py
@@ -1,0 +1,52 @@
+"""add policies table
+
+Revision ID: 004
+Revises: 003
+Create Date: 2026-04-21 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "004"
+down_revision: Union[str, None] = "003"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "policies",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("name", sa.String(255), nullable=False, unique=True),
+        sa.Column("description", sa.Text, nullable=True),
+        sa.Column("is_active", sa.Boolean, nullable=False, server_default="false"),
+        sa.Column("action", sa.String(50), nullable=False, server_default="inform"),
+        sa.Column("min_severity", sa.String(50), nullable=False, server_default="medium"),
+        sa.Column("enabled_scan_types", sa.JSON, nullable=False, server_default="[]"),
+        sa.Column("rule_blocklist", sa.JSON, nullable=False, server_default="[]"),
+        sa.Column("rule_allowlist", sa.JSON, nullable=False, server_default="[]"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_policies_name", "policies", ["name"], unique=True)
+    op.create_index("ix_policies_is_active", "policies", ["is_active"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_policies_is_active", table_name="policies")
+    op.drop_index("ix_policies_name", table_name="policies")
+    op.drop_table("policies")

--- a/backend/alembic/versions/005_add_secret_patterns_table.py
+++ b/backend/alembic/versions/005_add_secret_patterns_table.py
@@ -1,0 +1,47 @@
+"""add secret_patterns table
+
+Revision ID: 005
+Revises: 004
+Create Date: 2026-04-21 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "005"
+down_revision: Union[str, None] = "004"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "secret_patterns",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("name", sa.String(256), nullable=False),
+        sa.Column("description", sa.Text, nullable=True),
+        sa.Column("pattern", sa.Text, nullable=False),
+        sa.Column("severity", sa.String(50), nullable=False, server_default="high"),
+        sa.Column("is_active", sa.Boolean, nullable=False, server_default="true"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_secret_patterns_is_active", "secret_patterns", ["is_active"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_secret_patterns_is_active", table_name="secret_patterns")
+    op.drop_table("secret_patterns")

--- a/backend/app/api/v1/policies.py
+++ b/backend/app/api/v1/policies.py
@@ -1,0 +1,246 @@
+import math
+import uuid
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_db
+from app.models.finding import Finding
+from app.models.policy import Policy
+from app.schemas.policy import (
+    PaginatedPolicies,
+    PolicyCreate,
+    PolicyEvaluationResult,
+    PolicyResponse,
+    PolicyUpdate,
+)
+from app.services.policy_evaluator import evaluate_policy
+
+router = APIRouter(prefix="/policies", tags=["policies"])
+
+
+@router.get("", response_model=PaginatedPolicies)
+async def list_policies(
+    is_active: Optional[bool] = Query(None),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+    db: AsyncSession = Depends(get_db),
+):
+    q = select(Policy)
+    if is_active is not None:
+        q = q.where(Policy.is_active == is_active)
+
+    from sqlalchemy import func
+    total_result = await db.execute(select(func.count()).select_from(q.subquery()))
+    total = total_result.scalar_one()
+
+    q = q.order_by(Policy.created_at.desc()).offset((page - 1) * page_size).limit(page_size)
+    result = await db.execute(q)
+    policies = result.scalars().all()
+
+    return PaginatedPolicies(
+        items=policies,
+        total=total,
+        page=page,
+        page_size=page_size,
+        pages=max(1, math.ceil(total / page_size)),
+    )
+
+
+@router.post("", response_model=PolicyResponse, status_code=201)
+async def create_policy(payload: PolicyCreate, db: AsyncSession = Depends(get_db)):
+    existing = await db.execute(select(Policy).where(Policy.name == payload.name))
+    if existing.scalar_one_or_none():
+        raise HTTPException(status_code=409, detail="A policy with this name already exists")
+
+    policy = Policy(**payload.model_dump())
+    db.add(policy)
+    await db.flush()
+    await db.refresh(policy)
+    return policy
+
+
+@router.get("/evaluate/all", response_model=List[PolicyEvaluationResult])
+async def evaluate_all_active(
+    application_id: Optional[uuid.UUID] = Query(None, description="Filter findings by application"),
+    db: AsyncSession = Depends(get_db),
+):
+    """Evaluate all active policies against current open findings."""
+    policies_result = await db.execute(select(Policy).where(Policy.is_active == True))  # noqa: E712
+    policies = policies_result.scalars().all()
+
+    findings_q = select(Finding).where(Finding.status == "open")
+    if application_id:
+        findings_q = findings_q.where(Finding.application_id == application_id)
+    findings_result = await db.execute(findings_q)
+    findings = findings_result.scalars().all()
+
+    return [evaluate_policy(p, list(findings)) for p in policies]
+
+
+@router.get("/{policy_id}", response_model=PolicyResponse)
+async def get_policy(policy_id: uuid.UUID, db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(Policy).where(Policy.id == policy_id))
+    policy = result.scalar_one_or_none()
+    if not policy:
+        raise HTTPException(status_code=404, detail="Policy not found")
+    return policy
+
+
+@router.patch("/{policy_id}", response_model=PolicyResponse)
+async def update_policy(
+    policy_id: uuid.UUID, payload: PolicyUpdate, db: AsyncSession = Depends(get_db)
+):
+    result = await db.execute(select(Policy).where(Policy.id == policy_id))
+    policy = result.scalar_one_or_none()
+    if not policy:
+        raise HTTPException(status_code=404, detail="Policy not found")
+
+    if payload.name is not None and payload.name != policy.name:
+        existing = await db.execute(select(Policy).where(Policy.name == payload.name))
+        if existing.scalar_one_or_none():
+            raise HTTPException(status_code=409, detail="A policy with this name already exists")
+
+    for field, value in payload.model_dump(exclude_unset=True).items():
+        setattr(policy, field, value)
+
+    await db.flush()
+    await db.refresh(policy)
+    return policy
+
+
+@router.post("/seed", status_code=201)
+async def seed_default_policies(db: AsyncSession = Depends(get_db)):
+    """Create default security policies if none exist. Idempotent."""
+    existing = await db.execute(select(Policy))
+    if existing.scalars().first():
+        return {"message": "Policies already exist — seed skipped", "policies_created": 0}
+
+    DEFAULT_POLICIES = [
+        {
+            "name": "Baseline SAST Policy",
+            "description": "Flag SAST findings at medium severity or above. Intended to inform developers without blocking pipelines.",
+            "is_active": True,
+            "action": "inform",
+            "min_severity": "medium",
+            "enabled_scan_types": ["sast"],
+            "rule_blocklist": [],
+            "rule_allowlist": [],
+        },
+        {
+            "name": "Critical Vulnerability Block",
+            "description": "Block deployment when critical CVEs are found in SCA or container scans. CIS L1-aligned.",
+            "is_active": True,
+            "action": "block",
+            "min_severity": "critical",
+            "enabled_scan_types": ["sca", "container"],
+            "rule_blocklist": [],
+            "rule_allowlist": [],
+        },
+        {
+            "name": "High Vulnerability Watch",
+            "description": "Track high-severity CVEs across dependency and container scans. Inform only — escalate to block after triage.",
+            "is_active": True,
+            "action": "inform",
+            "min_severity": "high",
+            "enabled_scan_types": ["sca", "container"],
+            "rule_blocklist": [],
+            "rule_allowlist": [],
+        },
+        {
+            "name": "Secrets Detection",
+            "description": "Block on any hardcoded secrets or credentials regardless of severity. Any matched rule immediately blocks.",
+            "is_active": True,
+            "action": "block",
+            "min_severity": "info",
+            "enabled_scan_types": ["secrets"],
+            "rule_blocklist": [
+                "generic.secrets.security.detected-generic-secret",
+                "python.django.security.audit.django-secret-key",
+                "javascript.lang.security.audit.hardcoded-credentials",
+                "generic.github.security.github-personal-access-token",
+                "generic.aws.security.aws-secret-access-key",
+            ],
+            "rule_allowlist": [],
+        },
+        {
+            "name": "IaC Security (CIS Level 1)",
+            "description": (
+                "Block IaC findings that violate CIS AWS Foundations Benchmark Level 1 controls. "
+                "Covers IAM least-privilege, S3 public access, unrestricted SSH/RDP, "
+                "CloudTrail integrity, RDS encryption, KMS rotation, and EC2 IMDSv2."
+            ),
+            "is_active": True,
+            "action": "block",
+            "min_severity": "medium",
+            "enabled_scan_types": ["iac"],
+            "rule_blocklist": [
+                # IAM
+                "CKV_AWS_1",   # No IAM policy with full admin privileges (*:*)
+                # Security Groups
+                "CKV_AWS_24",  # No unrestricted SSH (port 22) ingress from 0.0.0.0/0
+                "CKV_AWS_25",  # No unrestricted RDP (port 3389) ingress from 0.0.0.0/0
+                # S3
+                "CKV_AWS_18",  # S3 access logging enabled
+                "CKV_AWS_19",  # S3 server-side encryption enabled
+                "CKV_AWS_20",  # S3 not publicly accessible via ACL
+                "CKV_AWS_53",  # S3 BlockPublicAcls
+                "CKV_AWS_54",  # S3 BlockPublicPolicy
+                "CKV_AWS_55",  # S3 IgnorePublicAcls
+                "CKV_AWS_56",  # S3 RestrictPublicBuckets
+                # CloudTrail
+                "CKV_AWS_36",  # CloudTrail log file validation enabled
+                "CKV_AWS_67",  # CloudTrail enabled in all regions
+                # RDS
+                "CKV_AWS_16",  # RDS storage encrypted at rest
+                "CKV_AWS_17",  # RDS instance not publicly accessible
+                # KMS
+                "CKV_AWS_7",   # KMS key rotation enabled
+                # EC2
+                "CKV_AWS_79",  # EC2 IMDSv2 required (disables IMDSv1)
+            ],
+            "rule_allowlist": [],
+        },
+    ]
+
+    count = 0
+    for policy_data in DEFAULT_POLICIES:
+        policy = Policy(**policy_data)
+        db.add(policy)
+        count += 1
+
+    await db.flush()
+    return {"message": f"Created {count} default policies", "policies_created": count}
+
+
+@router.delete("/{policy_id}", status_code=204)
+async def delete_policy(policy_id: uuid.UUID, db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(Policy).where(Policy.id == policy_id))
+    policy = result.scalar_one_or_none()
+    if not policy:
+        raise HTTPException(status_code=404, detail="Policy not found")
+    await db.delete(policy)
+    await db.flush()
+
+
+@router.post("/{policy_id}/evaluate", response_model=PolicyEvaluationResult)
+async def evaluate_policy_endpoint(
+    policy_id: uuid.UUID,
+    application_id: Optional[uuid.UUID] = Query(None, description="Filter findings by application"),
+    db: AsyncSession = Depends(get_db),
+):
+    """Evaluate a specific policy against current open findings."""
+    result = await db.execute(select(Policy).where(Policy.id == policy_id))
+    policy = result.scalar_one_or_none()
+    if not policy:
+        raise HTTPException(status_code=404, detail="Policy not found")
+
+    findings_q = select(Finding).where(Finding.status == "open")
+    if application_id:
+        findings_q = findings_q.where(Finding.application_id == application_id)
+    findings_result = await db.execute(findings_q)
+    findings = findings_result.scalars().all()
+
+    return evaluate_policy(policy, list(findings))

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.api.v1 import applications, cicd_scans, findings, github, remediation, reports, scans, seed
+from app.api.v1 import applications, cicd_scans, findings, github, policies, remediation, reports, scans, secrets, seed
 
 api_router = APIRouter(prefix="/api/v1")
 
@@ -12,3 +12,5 @@ api_router.include_router(reports.router)
 api_router.include_router(seed.router)
 api_router.include_router(github.router)
 api_router.include_router(cicd_scans.router)
+api_router.include_router(policies.router)
+api_router.include_router(secrets.router)

--- a/backend/app/api/v1/secrets.py
+++ b/backend/app/api/v1/secrets.py
@@ -65,27 +65,36 @@ async def get_secret_finding_stats(
     application_id: Optional[uuid.UUID] = Query(None),
     db: AsyncSession = Depends(get_db),
 ):
-    q = select(Finding).where(Finding.finding_type == "secrets")
+    filters = [Finding.finding_type == "secrets"]
     if application_id:
-        q = q.where(Finding.application_id == application_id)
+        filters.append(Finding.application_id == application_id)
 
-    result = await db.execute(q)
-    findings = result.scalars().all()
+    total = (await db.execute(select(func.count()).select_from(Finding).where(*filters))).scalar_one()
 
-    by_rule: dict = {}
-    for f in findings:
-        rule = f.rule_id or "unknown"
-        by_rule[rule] = by_rule.get(rule, 0) + 1
+    sev_rows = (await db.execute(
+        select(Finding.severity, func.count()).where(*filters).group_by(Finding.severity)
+    )).all()
+    severity_counts = {s: c for s, c in sev_rows}
+
+    status_rows = (await db.execute(
+        select(Finding.status, func.count()).where(*filters).group_by(Finding.status)
+    )).all()
+    status_counts = {s: c for s, c in status_rows}
+
+    rule_rows = (await db.execute(
+        select(Finding.rule_id, func.count()).where(*filters).group_by(Finding.rule_id)
+    )).all()
+    by_rule = {(r or "unknown"): c for r, c in rule_rows}
 
     return {
-        "total": len(findings),
-        "critical": sum(1 for f in findings if f.severity == "critical"),
-        "high": sum(1 for f in findings if f.severity == "high"),
-        "medium": sum(1 for f in findings if f.severity == "medium"),
-        "low": sum(1 for f in findings if f.severity == "low"),
-        "open": sum(1 for f in findings if f.status == "open"),
-        "accepted": sum(1 for f in findings if f.status == "accepted"),
-        "false_positive": sum(1 for f in findings if f.status == "false_positive"),
+        "total": total,
+        "critical": severity_counts.get("critical", 0),
+        "high": severity_counts.get("high", 0),
+        "medium": severity_counts.get("medium", 0),
+        "low": severity_counts.get("low", 0),
+        "open": status_counts.get("open", 0),
+        "accepted": status_counts.get("accepted", 0),
+        "false_positive": status_counts.get("false_positive", 0),
         "by_rule": by_rule,
     }
 

--- a/backend/app/api/v1/secrets.py
+++ b/backend/app/api/v1/secrets.py
@@ -1,0 +1,227 @@
+import math
+import re
+import uuid
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_db
+from app.models.finding import Finding
+from app.models.secret_pattern import SecretPattern
+from app.schemas.finding import FindingResponse, FindingUpdate, PaginatedFindings
+from app.schemas.secret_pattern import (
+    PaginatedSecretPatterns,
+    SecretPatternCreate,
+    SecretPatternResponse,
+    SecretPatternTest,
+    SecretPatternTestResult,
+    SecretPatternUpdate,
+)
+
+router = APIRouter(prefix="/secrets", tags=["secrets"])
+
+
+# ---------------------------------------------------------------------------
+# Findings routes (secrets-specific view over the Finding model)
+# ---------------------------------------------------------------------------
+
+@router.get("/findings", response_model=PaginatedFindings)
+async def list_secret_findings(
+    application_id: Optional[uuid.UUID] = Query(None),
+    severity: Optional[str] = Query(None),
+    status: Optional[str] = Query(None),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+    db: AsyncSession = Depends(get_db),
+):
+    q = select(Finding).where(Finding.finding_type == "secrets")
+    if application_id:
+        q = q.where(Finding.application_id == application_id)
+    if severity:
+        q = q.where(Finding.severity == severity)
+    if status:
+        q = q.where(Finding.status == status)
+
+    total_result = await db.execute(select(func.count()).select_from(q.subquery()))
+    total = total_result.scalar_one()
+
+    q = q.order_by(Finding.created_at.desc()).offset((page - 1) * page_size).limit(page_size)
+    result = await db.execute(q)
+    findings = result.scalars().all()
+
+    return PaginatedFindings(
+        items=findings,
+        total=total,
+        page=page,
+        page_size=page_size,
+        pages=max(1, math.ceil(total / page_size)),
+    )
+
+
+@router.get("/findings/stats")
+async def get_secret_finding_stats(
+    application_id: Optional[uuid.UUID] = Query(None),
+    db: AsyncSession = Depends(get_db),
+):
+    q = select(Finding).where(Finding.finding_type == "secrets")
+    if application_id:
+        q = q.where(Finding.application_id == application_id)
+
+    result = await db.execute(q)
+    findings = result.scalars().all()
+
+    by_rule: dict = {}
+    for f in findings:
+        rule = f.rule_id or "unknown"
+        by_rule[rule] = by_rule.get(rule, 0) + 1
+
+    return {
+        "total": len(findings),
+        "critical": sum(1 for f in findings if f.severity == "critical"),
+        "high": sum(1 for f in findings if f.severity == "high"),
+        "medium": sum(1 for f in findings if f.severity == "medium"),
+        "low": sum(1 for f in findings if f.severity == "low"),
+        "open": sum(1 for f in findings if f.status == "open"),
+        "accepted": sum(1 for f in findings if f.status == "accepted"),
+        "false_positive": sum(1 for f in findings if f.status == "false_positive"),
+        "by_rule": by_rule,
+    }
+
+
+@router.get("/findings/{finding_id}", response_model=FindingResponse)
+async def get_secret_finding(finding_id: uuid.UUID, db: AsyncSession = Depends(get_db)):
+    result = await db.execute(
+        select(Finding).where(Finding.id == finding_id, Finding.finding_type == "secrets")
+    )
+    finding = result.scalar_one_or_none()
+    if not finding:
+        raise HTTPException(status_code=404, detail="Secret finding not found")
+    return finding
+
+
+@router.patch("/findings/{finding_id}", response_model=FindingResponse)
+async def update_secret_finding(
+    finding_id: uuid.UUID,
+    payload: FindingUpdate,
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(
+        select(Finding).where(Finding.id == finding_id, Finding.finding_type == "secrets")
+    )
+    finding = result.scalar_one_or_none()
+    if not finding:
+        raise HTTPException(status_code=404, detail="Secret finding not found")
+
+    for field, value in payload.model_dump(exclude_unset=True).items():
+        setattr(finding, field, value)
+
+    if payload.status == "fixed":
+        from datetime import datetime, timezone
+        finding.fixed_at = datetime.now(timezone.utc)
+
+    await db.flush()
+    await db.refresh(finding)
+    return finding
+
+
+# ---------------------------------------------------------------------------
+# Custom pattern CRUD
+# ---------------------------------------------------------------------------
+
+@router.get("/patterns", response_model=PaginatedSecretPatterns)
+async def list_patterns(
+    is_active: Optional[bool] = Query(None),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=100),
+    db: AsyncSession = Depends(get_db),
+):
+    q = select(SecretPattern)
+    if is_active is not None:
+        q = q.where(SecretPattern.is_active == is_active)
+
+    total_result = await db.execute(select(func.count()).select_from(q.subquery()))
+    total = total_result.scalar_one()
+
+    q = q.order_by(SecretPattern.created_at.desc()).offset((page - 1) * page_size).limit(page_size)
+    result = await db.execute(q)
+    patterns = result.scalars().all()
+
+    return PaginatedSecretPatterns(
+        items=patterns,
+        total=total,
+        page=page,
+        page_size=page_size,
+        pages=max(1, math.ceil(total / page_size)),
+    )
+
+
+@router.post("/patterns", response_model=SecretPatternResponse, status_code=201)
+async def create_pattern(payload: SecretPatternCreate, db: AsyncSession = Depends(get_db)):
+    try:
+        re.compile(payload.pattern)
+    except re.error as e:
+        raise HTTPException(status_code=422, detail=f"Invalid regex pattern: {e}")
+
+    pattern = SecretPattern(**payload.model_dump())
+    db.add(pattern)
+    await db.flush()
+    await db.refresh(pattern)
+    return pattern
+
+
+@router.get("/patterns/{pattern_id}", response_model=SecretPatternResponse)
+async def get_pattern(pattern_id: uuid.UUID, db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(SecretPattern).where(SecretPattern.id == pattern_id))
+    pattern = result.scalar_one_or_none()
+    if not pattern:
+        raise HTTPException(status_code=404, detail="Pattern not found")
+    return pattern
+
+
+@router.put("/patterns/{pattern_id}", response_model=SecretPatternResponse)
+async def update_pattern(
+    pattern_id: uuid.UUID,
+    payload: SecretPatternUpdate,
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(select(SecretPattern).where(SecretPattern.id == pattern_id))
+    pattern = result.scalar_one_or_none()
+    if not pattern:
+        raise HTTPException(status_code=404, detail="Pattern not found")
+
+    if payload.pattern is not None:
+        try:
+            re.compile(payload.pattern)
+        except re.error as e:
+            raise HTTPException(status_code=422, detail=f"Invalid regex pattern: {e}")
+
+    for field, value in payload.model_dump(exclude_unset=True).items():
+        setattr(pattern, field, value)
+
+    await db.flush()
+    await db.refresh(pattern)
+    return pattern
+
+
+@router.delete("/patterns/{pattern_id}", status_code=204)
+async def delete_pattern(pattern_id: uuid.UUID, db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(SecretPattern).where(SecretPattern.id == pattern_id))
+    pattern = result.scalar_one_or_none()
+    if not pattern:
+        raise HTTPException(status_code=404, detail="Pattern not found")
+    await db.delete(pattern)
+    await db.flush()
+
+
+@router.post("/patterns/test", response_model=SecretPatternTestResult)
+async def test_pattern(payload: SecretPatternTest):
+    try:
+        compiled = re.compile(payload.pattern)
+    except re.error as e:
+        return SecretPatternTestResult(matches=[], match_count=0, valid=False, error=str(e))
+
+    matches = compiled.findall(payload.sample_text)
+    str_matches = [m if isinstance(m, str) else str(m) for m in matches]
+    return SecretPatternTestResult(matches=str_matches, match_count=len(str_matches), valid=True)

--- a/backend/app/api/v1/seed.py
+++ b/backend/app/api/v1/seed.py
@@ -40,6 +40,12 @@ SEED_FINDINGS = [
     ("CSRF protection disabled", "CSRF exempt decorator found", "medium", "SAST", "semgrep", "src/api/handlers/auth.py", 15, "python.django.security.audit.csrf-exempt", None, None, None, None, None),
     ("Insecure HTTP transport", "Credentials sent over unencrypted HTTP", "low", "SAST", "semgrep", "src/api/handlers/users.py", 312, "python.lang.security.audit.insecure-transport.requests.request-with-http", None, None, None, None, None),
     ("CVE-2024-2961: glibc iconv overflow", "glibc iconv buffer overflow", "high", "SCA", "trivy", None, None, None, "CVE-2024-2961", "libc6", "2.37-15", "2.38", 8.8),
+    # IaC / Checkov findings
+    ("IAM policy allows full admin access (*:*)", "IAM policy grants all actions on all resources — violates CIS AWS 1.0 L1 (CKV_AWS_1)", "critical", "IaC", "checkov", "terraform/iam.tf", 14, "CKV_AWS_1", None, None, None, None, None),
+    ("Security group allows unrestricted SSH ingress (0.0.0.0/0:22)", "Inbound SSH open to the internet — violates CIS AWS 4.1 L1 (CKV_AWS_24)", "critical", "IaC", "checkov", "terraform/sg.tf", 31, "CKV_AWS_24", None, None, None, None, None),
+    ("S3 bucket publicly accessible via ACL", "S3 ACL grants public read/write access — violates CIS AWS 2.1 L1 (CKV_AWS_20)", "high", "IaC", "checkov", "terraform/s3.tf", 8, "CKV_AWS_20", None, None, None, None, None),
+    ("RDS instance storage not encrypted at rest", "RDS storage encryption disabled — violates CIS AWS 2.3 L1 (CKV_AWS_16)", "high", "IaC", "checkov", "terraform/rds.tf", 22, "CKV_AWS_16", None, None, None, None, None),
+    ("CloudTrail log file validation not enabled", "CloudTrail integrity validation disabled — violates CIS AWS 3.2 L1 (CKV_AWS_36)", "medium", "IaC", "checkov", "terraform/cloudtrail.tf", 5, "CKV_AWS_36", None, None, None, None, None),
 ]
 
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,7 +1,9 @@
 from app.models.application import Application
 from app.models.cicd_scan import CiCdScan
 from app.models.finding import Finding
+from app.models.policy import Policy
 from app.models.remediation import Remediation
 from app.models.scan import Scan
+from app.models.secret_pattern import SecretPattern
 
-__all__ = ["Application", "Scan", "Finding", "Remediation", "CiCdScan"]
+__all__ = ["Application", "Scan", "Finding", "Remediation", "CiCdScan", "Policy", "SecretPattern"]

--- a/backend/app/models/policy.py
+++ b/backend/app/models/policy.py
@@ -1,0 +1,43 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import JSON as SA_JSON
+from sqlalchemy import Boolean, DateTime, String, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class Policy(Base):
+    __tablename__ = "policies"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    is_active: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+
+    # action taken when a finding violates this policy
+    # block | inform | both
+    action: Mapped[str] = mapped_column(String(50), default="inform", nullable=False)
+
+    # minimum severity to flag (critical > high > medium > low > info)
+    min_severity: Mapped[str] = mapped_column(String(50), default="medium", nullable=False)
+
+    # list of scan type labels to include: sast, sca, container, secrets, iac
+    # empty list means "all scan types"
+    enabled_scan_types: Mapped[list] = mapped_column(SA_JSON, default=list, nullable=False)
+
+    # rule IDs / CVE IDs to always flag regardless of severity
+    rule_blocklist: Mapped[list] = mapped_column(SA_JSON, default=list, nullable=False)
+
+    # rule IDs / CVE IDs to always ignore (overrides everything)
+    rule_allowlist: Mapped[list] = mapped_column(SA_JSON, default=list, nullable=False)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )

--- a/backend/app/models/secret_pattern.py
+++ b/backend/app/models/secret_pattern.py
@@ -1,0 +1,25 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, String, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class SecretPattern(Base):
+    __tablename__ = "secret_patterns"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = mapped_column(String(256), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    pattern: Mapped[str] = mapped_column(Text, nullable=False)
+    severity: Mapped[str] = mapped_column(String(50), default="high", nullable=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )

--- a/backend/app/schemas/policy.py
+++ b/backend/app/schemas/policy.py
@@ -1,0 +1,118 @@
+import uuid
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+
+VALID_SCAN_TYPES = {"sast", "sca", "container", "secrets", "iac"}
+VALID_SEVERITIES = ["critical", "high", "medium", "low", "info"]
+VALID_ACTIONS = {"block", "inform", "both"}
+
+
+class PolicyBase(BaseModel):
+    name: str
+    description: Optional[str] = None
+    is_active: bool = False
+    action: str = "inform"
+    min_severity: str = "medium"
+    enabled_scan_types: List[str] = []
+    rule_blocklist: List[str] = []
+    rule_allowlist: List[str] = []
+
+    @field_validator("action")
+    @classmethod
+    def validate_action(cls, v: str) -> str:
+        if v not in VALID_ACTIONS:
+            raise ValueError(f"action must be one of {sorted(VALID_ACTIONS)}")
+        return v
+
+    @field_validator("min_severity")
+    @classmethod
+    def validate_severity(cls, v: str) -> str:
+        if v not in VALID_SEVERITIES:
+            raise ValueError(f"min_severity must be one of {VALID_SEVERITIES}")
+        return v
+
+    @field_validator("enabled_scan_types")
+    @classmethod
+    def validate_scan_types(cls, v: List[str]) -> List[str]:
+        invalid = set(v) - VALID_SCAN_TYPES
+        if invalid:
+            raise ValueError(f"Invalid scan types: {invalid}. Valid: {sorted(VALID_SCAN_TYPES)}")
+        return v
+
+
+class PolicyCreate(PolicyBase):
+    pass
+
+
+class PolicyUpdate(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
+    is_active: Optional[bool] = None
+    action: Optional[str] = None
+    min_severity: Optional[str] = None
+    enabled_scan_types: Optional[List[str]] = None
+    rule_blocklist: Optional[List[str]] = None
+    rule_allowlist: Optional[List[str]] = None
+
+    @field_validator("action")
+    @classmethod
+    def validate_action(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None and v not in VALID_ACTIONS:
+            raise ValueError(f"action must be one of {sorted(VALID_ACTIONS)}")
+        return v
+
+    @field_validator("min_severity")
+    @classmethod
+    def validate_severity(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None and v not in VALID_SEVERITIES:
+            raise ValueError(f"min_severity must be one of {VALID_SEVERITIES}")
+        return v
+
+    @field_validator("enabled_scan_types")
+    @classmethod
+    def validate_scan_types(cls, v: Optional[List[str]]) -> Optional[List[str]]:
+        if v is not None:
+            invalid = set(v) - VALID_SCAN_TYPES
+            if invalid:
+                raise ValueError(f"Invalid scan types: {invalid}. Valid: {sorted(VALID_SCAN_TYPES)}")
+        return v
+
+
+class PolicyResponse(PolicyBase):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    created_at: datetime
+    updated_at: datetime
+
+
+class PaginatedPolicies(BaseModel):
+    items: List[PolicyResponse]
+    total: int
+    page: int
+    page_size: int
+    pages: int
+
+
+class PolicyViolation(BaseModel):
+    finding_id: uuid.UUID
+    finding_title: str
+    severity: str
+    scanner: str
+    finding_type: str
+    rule_id: Optional[str] = None
+    cve_id: Optional[str] = None
+    reason: str  # "severity_threshold" | "blocklisted_rule"
+
+
+class PolicyEvaluationResult(BaseModel):
+    policy_id: uuid.UUID
+    policy_name: str
+    is_active: bool
+    action: str
+    total_violations: int
+    blocked: bool
+    violations: List[PolicyViolation]

--- a/backend/app/schemas/secret_pattern.py
+++ b/backend/app/schemas/secret_pattern.py
@@ -1,0 +1,53 @@
+import uuid
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict
+
+
+class SecretPatternBase(BaseModel):
+    name: str
+    description: Optional[str] = None
+    pattern: str
+    severity: str = "high"
+    is_active: bool = True
+
+
+class SecretPatternCreate(SecretPatternBase):
+    pass
+
+
+class SecretPatternUpdate(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
+    pattern: Optional[str] = None
+    severity: Optional[str] = None
+    is_active: Optional[bool] = None
+
+
+class SecretPatternResponse(SecretPatternBase):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    created_at: datetime
+    updated_at: datetime
+
+
+class SecretPatternTest(BaseModel):
+    pattern: str
+    sample_text: str
+
+
+class SecretPatternTestResult(BaseModel):
+    matches: List[str]
+    match_count: int
+    valid: bool
+    error: Optional[str] = None
+
+
+class PaginatedSecretPatterns(BaseModel):
+    items: List[SecretPatternResponse]
+    total: int
+    page: int
+    page_size: int
+    pages: int

--- a/backend/app/schemas/secret_pattern.py
+++ b/backend/app/schemas/secret_pattern.py
@@ -1,6 +1,6 @@
 import uuid
 from datetime import datetime
-from typing import List, Optional
+from typing import List, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict
 
@@ -9,7 +9,7 @@ class SecretPatternBase(BaseModel):
     name: str
     description: Optional[str] = None
     pattern: str
-    severity: str = "high"
+    severity: Literal["critical", "high", "medium", "low"] = "high"
     is_active: bool = True
 
 
@@ -21,7 +21,7 @@ class SecretPatternUpdate(BaseModel):
     name: Optional[str] = None
     description: Optional[str] = None
     pattern: Optional[str] = None
-    severity: Optional[str] = None
+    severity: Optional[Literal["critical", "high", "medium", "low"]] = None
     is_active: Optional[bool] = None
 
 

--- a/backend/app/services/deduplication.py
+++ b/backend/app/services/deduplication.py
@@ -27,7 +27,7 @@ def _match_key(raw: dict) -> tuple:
     """Return a tuple that uniquely identifies a finding for deduplication."""
     ftype = (raw.get("finding_type") or "").lower()
     if ftype == "secrets" and raw.get("rule_id") and raw.get("file_path"):
-        return ("secrets", raw["rule_id"], raw["file_path"], str(raw.get("line_number") or ""))
+        return ("secrets", raw["rule_id"], raw["file_path"])
     if raw.get("rule_id") and raw.get("file_path"):
         return ("sast", raw["rule_id"], raw["file_path"])
     if raw.get("cve_id") and raw.get("package_name"):

--- a/backend/app/services/deduplication.py
+++ b/backend/app/services/deduplication.py
@@ -25,6 +25,9 @@ logger = logging.getLogger(__name__)
 
 def _match_key(raw: dict) -> tuple:
     """Return a tuple that uniquely identifies a finding for deduplication."""
+    ftype = (raw.get("finding_type") or "").lower()
+    if ftype == "secrets" and raw.get("rule_id") and raw.get("file_path"):
+        return ("secrets", raw["rule_id"], raw["file_path"], str(raw.get("line_number") or ""))
     if raw.get("rule_id") and raw.get("file_path"):
         return ("sast", raw["rule_id"], raw["file_path"])
     if raw.get("cve_id") and raw.get("package_name"):

--- a/backend/app/services/policy_evaluator.py
+++ b/backend/app/services/policy_evaluator.py
@@ -1,0 +1,125 @@
+"""Policy evaluation service.
+
+Maps policy scan type labels to Finding model fields:
+  sast      → finding_type="SAST",      scanner="semgrep"
+  sca       → finding_type="SCA",       scanner="trivy"
+  container → finding_type="container", scanner="grype"
+  secrets   → finding_type="secrets",   scanner="gitleaks"
+  iac       → finding_type="IaC",       scanner="checkov"
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.models.finding import Finding
+    from app.models.policy import Policy
+
+SEVERITY_ORDER = ["info", "low", "medium", "high", "critical"]
+
+# Maps policy scan-type label → (finding_type value, scanner value)
+SCAN_TYPE_MAP: dict[str, tuple[str, str]] = {
+    "sast": ("SAST", "semgrep"),
+    "sca": ("SCA", "trivy"),
+    "container": ("container", "grype"),
+    "secrets": ("secrets", "gitleaks"),
+    "iac": ("IaC", "checkov"),
+}
+
+
+def _severity_index(severity: str) -> int:
+    try:
+        return SEVERITY_ORDER.index(severity.lower())
+    except ValueError:
+        return 0
+
+
+def _finding_scan_type(finding: "Finding") -> str | None:
+    """Return the policy scan-type label for a finding, or None if unknown."""
+    for label, (ftype, scanner) in SCAN_TYPE_MAP.items():
+        if finding.finding_type == ftype or finding.scanner == scanner:
+            return label
+    return None
+
+
+def evaluate_policy(policy: "Policy", findings: list["Finding"]) -> dict:
+    """Evaluate a list of findings against a single policy.
+
+    Returns a dict matching PolicyEvaluationResult schema.
+    """
+    from app.schemas.policy import PolicyEvaluationResult, PolicyViolation
+
+    min_idx = _severity_index(policy.min_severity)
+    enabled_types: set[str] = set(policy.enabled_scan_types) if policy.enabled_scan_types else set()
+    blocklist: set[str] = {r.lower() for r in (policy.rule_blocklist or [])}
+    allowlist: set[str] = {r.lower() for r in (policy.rule_allowlist or [])}
+
+    violations: list[PolicyViolation] = []
+
+    for finding in findings:
+        if finding.status != "open":
+            continue
+
+        # Allowlist overrides everything — skip this finding
+        rule_key = (finding.rule_id or "").lower()
+        cve_key = (finding.cve_id or "").lower()
+        if (rule_key and rule_key in allowlist) or (cve_key and cve_key in allowlist):
+            continue
+
+        # Filter by enabled scan types (empty = all types)
+        if enabled_types:
+            scan_type_label = _finding_scan_type(finding)
+            if scan_type_label not in enabled_types:
+                continue
+
+        # Check blocklist (always flagged regardless of severity)
+        if (rule_key and rule_key in blocklist) or (cve_key and cve_key in blocklist):
+            violations.append(
+                PolicyViolation(
+                    finding_id=finding.id,
+                    finding_title=finding.title,
+                    severity=finding.severity,
+                    scanner=finding.scanner,
+                    finding_type=finding.finding_type,
+                    rule_id=finding.rule_id,
+                    cve_id=finding.cve_id,
+                    reason="blocklisted_rule",
+                )
+            )
+            continue
+
+        # Check severity threshold
+        if _severity_index(finding.severity) >= min_idx:
+            violations.append(
+                PolicyViolation(
+                    finding_id=finding.id,
+                    finding_title=finding.title,
+                    severity=finding.severity,
+                    scanner=finding.scanner,
+                    finding_type=finding.finding_type,
+                    rule_id=finding.rule_id,
+                    cve_id=finding.cve_id,
+                    reason="severity_threshold",
+                )
+            )
+
+    blocked = len(violations) > 0 and policy.action in ("block", "both")
+
+    return PolicyEvaluationResult(
+        policy_id=policy.id,
+        policy_name=policy.name,
+        is_active=policy.is_active,
+        action=policy.action,
+        total_violations=len(violations),
+        blocked=blocked,
+        violations=violations,
+    ).model_dump()
+
+
+def evaluate_all_active_policies(
+    db,  # SQLAlchemy Session (sync or async caller passes findings directly)
+    findings: list["Finding"],
+    policies: list["Policy"],
+) -> list[dict]:
+    """Evaluate all provided active policies against the given findings."""
+    return [evaluate_policy(p, findings) for p in policies]

--- a/backend/app/services/scanner.py
+++ b/backend/app/services/scanner.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import re
 import shutil
 import subprocess
 import tempfile
@@ -20,6 +19,25 @@ def _mask_secret(secret: str) -> str:
     if not secret or len(secret) < 4:
         return "****"
     return f"****{secret[-4:]}"
+
+
+_GITLEAKS_SEVERITY: dict[str, str] = {
+    "critical": "critical",
+    "high": "high",
+    "medium": "medium",
+    "low": "low",
+}
+
+
+def _gitleaks_severity(item: dict, custom_severity_map: dict[str, str]) -> str:
+    rule_id = item.get("RuleID", "")
+    if rule_id in custom_severity_map:
+        return custom_severity_map[rule_id]
+    for tag in item.get("Tags") or []:
+        sev = _GITLEAKS_SEVERITY.get(tag.lower())
+        if sev:
+            return sev
+    return "high"
 
 
 _SEMGREP_SEVERITY: dict[str, str] = {
@@ -287,23 +305,28 @@ class RealScannerService:
         custom_patterns: list[dict] | None = None,
     ) -> list[dict[str, Any]]:
         config_path: Path | None = None
+        custom_severity_map: dict[str, str] = {}
         try:
             if custom_patterns:
                 toml_lines = ['title = "snitch"\n', "\n", "[extend]\n", "useDefault = true\n"]
                 for p in custom_patterns:
+                    safe_name = p["name"].replace("\\", "\\\\").replace('"', '\\"')
+                    safe_pattern = p["pattern"].replace("'''", "\\'\\'\\'")
+                    rule_id = f"custom-{p['id']}"
+                    custom_severity_map[rule_id] = p["severity"]
                     toml_lines += [
                         "\n[[rules]]\n",
-                        f'id = "custom-{p["id"]}"\n',
-                        f'description = "{p["name"]}"\n',
-                        f"regex = '''{p['pattern']}'''\n",
+                        f'id = "{rule_id}"\n',
+                        f'description = "{safe_name}"\n',
+                        f"regex = '''{safe_pattern}'''\n",
                         f'severity = "{p["severity"].upper()}"\n',
                     ]
-                tmp_cfg = tempfile.NamedTemporaryFile(
+                with tempfile.NamedTemporaryFile(
                     mode="w", suffix=".toml", delete=False, prefix="snitch-gitleaks-"
-                )
-                tmp_cfg.writelines(toml_lines)
-                tmp_cfg.flush()
-                config_path = Path(tmp_cfg.name)
+                ) as tmp_cfg:
+                    tmp_cfg.writelines(toml_lines)
+                    tmp_cfg.flush()
+                    config_path = Path(tmp_cfg.name)
 
             cmd = [
                 "gitleaks", "detect",
@@ -366,7 +389,7 @@ class RealScannerService:
                 findings.append({
                     "title": f"Secret detected: {description}"[:512],
                     "description": f"Rule: {rule_id}. Match context: {_mask_secret(secret or match_text)}",
-                    "severity": "high",
+                    "severity": _gitleaks_severity(item, custom_severity_map),
                     "finding_type": "secrets",
                     "scanner": "gitleaks",
                     "file_path": file_path,

--- a/backend/app/services/scanner.py
+++ b/backend/app/services/scanner.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 import shutil
 import subprocess
 import tempfile
@@ -15,6 +16,12 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Semgrep severity mapping
 # ---------------------------------------------------------------------------
+def _mask_secret(secret: str) -> str:
+    if not secret or len(secret) < 4:
+        return "****"
+    return f"****{secret[-4:]}"
+
+
 _SEMGREP_SEVERITY: dict[str, str] = {
     "ERROR": "high",
     "WARNING": "medium",
@@ -273,13 +280,119 @@ class RealScannerService:
         logger.info("govulncheck found %d findings in %s", len(findings), app.name)
         return findings
 
-    def run_scan(self, app: Application, scan_type: str = "all") -> list[dict[str, Any]]:
+    def run_gitleaks_scan(
+        self,
+        app: Application,
+        repo_path: Path,
+        custom_patterns: list[dict] | None = None,
+    ) -> list[dict[str, Any]]:
+        config_path: Path | None = None
+        try:
+            if custom_patterns:
+                toml_lines = ['title = "snitch"\n', "\n", "[extend]\n", "useDefault = true\n"]
+                for p in custom_patterns:
+                    toml_lines += [
+                        "\n[[rules]]\n",
+                        f'id = "custom-{p["id"]}"\n',
+                        f'description = "{p["name"]}"\n',
+                        f"regex = '''{p['pattern']}'''\n",
+                        f'severity = "{p["severity"].upper()}"\n',
+                    ]
+                tmp_cfg = tempfile.NamedTemporaryFile(
+                    mode="w", suffix=".toml", delete=False, prefix="snitch-gitleaks-"
+                )
+                tmp_cfg.writelines(toml_lines)
+                tmp_cfg.flush()
+                config_path = Path(tmp_cfg.name)
+
+            cmd = [
+                "gitleaks", "detect",
+                "--source", str(repo_path),
+                "--no-git",
+                "--report-format", "json",
+                "--report-path", "/dev/stdout",
+                "--exit-code", "0",
+            ]
+            if config_path:
+                cmd += ["--config", str(config_path)]
+
+            try:
+                result = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=300,
+                )
+            except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+                logger.error("gitleaks failed for %s: %s", app.name, e)
+                return []
+
+            if result.returncode != 0:
+                logger.error(
+                    "gitleaks error (exit %d) for %s:\nstderr: %s",
+                    result.returncode, app.name,
+                    result.stderr[:2000] if result.stderr else "",
+                )
+                return []
+
+            stdout = (result.stdout or "").strip()
+            if not stdout:
+                return []
+
+            try:
+                raw_output = json.loads(stdout)
+            except json.JSONDecodeError as e:
+                logger.error("gitleaks JSON parse error for %s: %s\nstdout: %s", app.name, e, stdout[:500])
+                return []
+
+            if not isinstance(raw_output, list):
+                return []
+
+            findings = []
+            for item in raw_output:
+                rule_id = item.get("RuleID", "")
+                file_path = item.get("File", "") or None
+                line_number = item.get("StartLine")
+                secret = item.get("Secret", "") or ""
+                match_text = item.get("Match", "") or ""
+                description = item.get("Description", rule_id)
+
+                try:
+                    if file_path:
+                        file_path = str(Path(file_path).relative_to(repo_path))
+                except ValueError:
+                    pass
+
+                findings.append({
+                    "title": f"Secret detected: {description}"[:512],
+                    "description": f"Rule: {rule_id}. Match context: {_mask_secret(secret or match_text)}",
+                    "severity": "high",
+                    "finding_type": "secrets",
+                    "scanner": "gitleaks",
+                    "file_path": file_path,
+                    "line_number": line_number,
+                    "rule_id": rule_id or None,
+                    "status": "open",
+                })
+
+            logger.info("gitleaks found %d findings in %s", len(findings), app.name)
+            return findings
+        finally:
+            if config_path and config_path.exists():
+                config_path.unlink(missing_ok=True)
+
+    def run_scan(
+        self,
+        app: Application,
+        scan_type: str = "all",
+        custom_secret_patterns: list[dict] | None = None,
+    ) -> list[dict[str, Any]]:
         """Clone the repo once and run only the scanner(s) requested by *scan_type*.
 
-        Supported values: ``"all"``, ``"semgrep"``, ``"trivy"``, ``"govulncheck"``.
+        Supported values: ``"all"``, ``"semgrep"``, ``"trivy"``, ``"govulncheck"``, ``"gitleaks"``.
         Unknown values fall back to ``"all"`` so callers are never silently broken.
         """
-        _KNOWN_TYPES = {"all", "semgrep", "trivy", "govulncheck"}
+        _KNOWN_TYPES = {"all", "semgrep", "trivy", "govulncheck", "gitleaks"}
         if scan_type not in _KNOWN_TYPES:
             logger.warning("Unknown scan_type %r — running all scanners", scan_type)
             scan_type = "all"
@@ -296,6 +409,8 @@ class RealScannerService:
                 findings += self.run_trivy_scan(app, repo_path)
             if scan_type in ("all", "govulncheck"):
                 findings += self.run_govulncheck_scan(app, repo_path)
+            if scan_type in ("all", "gitleaks"):
+                findings += self.run_gitleaks_scan(app, repo_path, custom_secret_patterns)
 
         return findings
 
@@ -307,6 +422,15 @@ class RealScannerService:
 # Mock scanner (kept for testing / when tools are unavailable)
 # ---------------------------------------------------------------------------
 import random
+
+GITLEAKS_RULES = [
+    ("aws-access-token", "AWS Access Key", "AKIA1234567890ABCDEF", "config/aws.py"),
+    ("github-pat", "GitHub Personal Access Token", "ghp_1234567890abcdef", ".env"),
+    ("generic-api-key", "Generic API Key", "api_key_xYzAbC123456", "src/config.py"),
+    ("stripe-access-token", "Stripe API Key", "sk_live_123456789abc", "payments/client.py"),
+    ("slack-webhook", "Slack Webhook URL", "https://hooks.slack.com/services/T00/B00/xxx", "notify.py"),
+    ("private-key", "Private Key", "-----BEGIN RSA PRIVATE KEY-----", "certs/server.key"),
+]
 
 SEMGREP_RULES = [
     ("python.django.security.injection.sql.sql-injection-using-db-cursor-fetchone", "SQL Injection via cursor", "critical"),
@@ -384,8 +508,25 @@ class MockScannerService:
             })
         return findings
 
+    def run_gitleaks_scan(self, app: Application) -> list[dict[str, Any]]:
+        findings = []
+        for _ in range(random.randint(1, 4)):
+            rule_id, title, secret, file_path = random.choice(GITLEAKS_RULES)
+            findings.append({
+                "title": f"Secret detected: {title}"[:512],
+                "description": f"Rule: {rule_id}. Match context: {_mask_secret(secret)}",
+                "severity": "high",
+                "finding_type": "secrets",
+                "scanner": "gitleaks",
+                "file_path": file_path,
+                "line_number": random.randint(1, 100),
+                "rule_id": rule_id,
+                "status": "open",
+            })
+        return findings
+
     def run_all_scans(self, app: Application) -> list[dict[str, Any]]:
-        return self.run_semgrep_scan(app) + self.run_trivy_scan(app)
+        return self.run_semgrep_scan(app) + self.run_trivy_scan(app) + self.run_gitleaks_scan(app)
 
 
 scanner_service = MockScannerService()

--- a/backend/app/worker/tasks.py
+++ b/backend/app/worker/tasks.py
@@ -17,6 +17,7 @@ from app.models.application import Application
 from app.models.cicd_scan import CiCdScan
 from app.models.finding import Finding
 from app.models.scan import Scan
+from app.models.secret_pattern import SecretPattern
 from app.worker.celery_app import celery_app
 
 logger = logging.getLogger(__name__)
@@ -68,10 +69,13 @@ def _upsert_findings_sync(
 
     def _key(f_dict: dict | Finding) -> tuple:
         if isinstance(f_dict, Finding):
-            return _raw_key(f_dict.rule_id, f_dict.file_path, f_dict.cve_id, f_dict.package_name, f_dict.scanner, f_dict.title)
-        return _raw_key(f_dict.get("rule_id"), f_dict.get("file_path"), f_dict.get("cve_id"), f_dict.get("package_name"), f_dict.get("scanner", ""), f_dict.get("title", ""))
+            return _raw_key(f_dict.rule_id, f_dict.file_path, f_dict.cve_id, f_dict.package_name, f_dict.scanner, f_dict.title, f_dict.finding_type)
+        return _raw_key(f_dict.get("rule_id"), f_dict.get("file_path"), f_dict.get("cve_id"), f_dict.get("package_name"), f_dict.get("scanner", ""), f_dict.get("title", ""), f_dict.get("finding_type", ""))
 
-    def _raw_key(rule_id, file_path, cve_id, package_name, scanner, title):
+    def _raw_key(rule_id, file_path, cve_id, package_name, scanner, title, finding_type=""):
+        ftype = (finding_type or "").lower()
+        if ftype == "secrets" and rule_id and file_path:
+            return ("secrets", rule_id, file_path)
         if rule_id and file_path:
             return ("sast", rule_id, file_path)
         if cve_id and package_name:
@@ -121,6 +125,44 @@ def _upsert_findings_sync(
     return created, updated
 
 
+def _evaluate_policies_sync(db: Session, application_id: uuid.UUID) -> dict:
+    """Evaluate all active policies against open findings for this application."""
+    from app.models.finding import Finding
+    from app.models.policy import Policy
+    from app.services.policy_evaluator import evaluate_policy
+
+    active_policies = db.execute(
+        select(Policy).where(Policy.is_active == True)  # noqa: E712
+    ).scalars().all()
+
+    if not active_policies:
+        return {"evaluated": 0, "blocked": False, "total_violations": 0}
+
+    findings = db.execute(
+        select(Finding).where(
+            Finding.application_id == application_id,
+            Finding.status == "open",
+        )
+    ).scalars().all()
+
+    results = [evaluate_policy(p, list(findings)) for p in active_policies]
+    blocked = any(r["blocked"] for r in results)
+    total_violations = sum(r["total_violations"] for r in results)
+
+    if blocked:
+        logger.warning(
+            "Policy violation: %d violations across %d policies for app %s",
+            total_violations, len(active_policies), application_id,
+        )
+
+    return {
+        "evaluated": len(active_policies),
+        "blocked": blocked,
+        "total_violations": total_violations,
+        "policies": [{"name": r["policy_name"], "violations": r["total_violations"], "blocked": r["blocked"]} for r in results],
+    }
+
+
 @celery_app.task(bind=True, name="app.worker.tasks.scan_application_task", max_retries=2)
 def scan_application_task(self, app_id: str, scan_type: str = "all") -> dict:
     """Run a real Semgrep + Trivy scan for a single application."""
@@ -158,8 +200,16 @@ def scan_application_task(self, app_id: str, scan_type: str = "all") -> dict:
         scan_id = scan.id
 
         try:
+            active_patterns = db.execute(
+                select(SecretPattern).where(SecretPattern.is_active == True)  # noqa: E712
+            ).scalars().all()
+            custom_secret_patterns = [
+                {"id": str(p.id), "name": p.name, "pattern": p.pattern, "severity": p.severity}
+                for p in active_patterns
+            ]
+
             svc = RealScannerService()
-            raw_findings = svc.run_scan(app, scan_type)
+            raw_findings = svc.run_scan(app, scan_type, custom_secret_patterns=custom_secret_patterns)
 
             created, updated = _upsert_findings_sync(db, application_id, scan_id, raw_findings)
 
@@ -172,6 +222,10 @@ def scan_application_task(self, app_id: str, scan_type: str = "all") -> dict:
             scan.completed_at = datetime.now(timezone.utc)
 
             _recalculate_risk(db, app)
+
+            # Evaluate all active policies against the updated findings
+            policy_summary = _evaluate_policies_sync(db, application_id)
+
             db.commit()
 
             return {
@@ -180,6 +234,7 @@ def scan_application_task(self, app_id: str, scan_type: str = "all") -> dict:
                 "findings": len(raw_findings),
                 "created": created,
                 "updated": updated,
+                "policy_evaluation": policy_summary,
             }
 
         except Exception as exc:
@@ -207,10 +262,13 @@ def _upsert_cicd_findings_sync(
 
     def _key(f_dict: dict | Finding) -> tuple:
         if isinstance(f_dict, Finding):
-            return _raw_key(f_dict.rule_id, f_dict.file_path, f_dict.cve_id, f_dict.package_name, f_dict.scanner, f_dict.title)
-        return _raw_key(f_dict.get("rule_id"), f_dict.get("file_path"), f_dict.get("cve_id"), f_dict.get("package_name"), f_dict.get("scanner", ""), f_dict.get("title", ""))
+            return _raw_key(f_dict.rule_id, f_dict.file_path, f_dict.cve_id, f_dict.package_name, f_dict.scanner, f_dict.title, f_dict.finding_type)
+        return _raw_key(f_dict.get("rule_id"), f_dict.get("file_path"), f_dict.get("cve_id"), f_dict.get("package_name"), f_dict.get("scanner", ""), f_dict.get("title", ""), f_dict.get("finding_type", ""))
 
-    def _raw_key(rule_id, file_path, cve_id, package_name, scanner, title):
+    def _raw_key(rule_id, file_path, cve_id, package_name, scanner, title, finding_type=""):
+        ftype = (finding_type or "").lower()
+        if ftype == "secrets" and rule_id and file_path:
+            return ("secrets", rule_id, file_path)
         if rule_id and file_path:
             return ("sast", rule_id, file_path)
         if cve_id and package_name:

--- a/backend/app/worker/tasks.py
+++ b/backend/app/worker/tasks.py
@@ -223,8 +223,12 @@ def scan_application_task(self, app_id: str, scan_type: str = "all") -> dict:
 
             _recalculate_risk(db, app)
 
-            # Evaluate all active policies against the updated findings
-            policy_summary = _evaluate_policies_sync(db, application_id)
+            # Only evaluate policies on full scans — partial scans produce incomplete
+            # finding sets and would cause false negatives in policy results.
+            if scan_type == "all":
+                policy_summary = _evaluate_policies_sync(db, application_id)
+            else:
+                policy_summary = {"skipped": True, "reason": f"partial scan ({scan_type})"}
 
             db.commit()
 

--- a/backend/tests/test_policies.py
+++ b/backend/tests/test_policies.py
@@ -1,0 +1,362 @@
+"""Tests for the Policy CRUD API and policy evaluation logic."""
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+BASE = "/api/v1/policies"
+
+
+async def _create_policy(client: AsyncClient, **overrides) -> dict:
+    payload = {
+        "name": f"Test Policy {uuid.uuid4().hex[:6]}",
+        "action": "inform",
+        "min_severity": "medium",
+        "enabled_scan_types": [],
+        "rule_blocklist": [],
+        "rule_allowlist": [],
+        **overrides,
+    }
+    resp = await client.post(BASE, json=payload)
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# CRUD
+# ---------------------------------------------------------------------------
+
+
+async def test_create_policy(client: AsyncClient):
+    data = await _create_policy(
+        client,
+        name="SAST Policy",
+        action="block",
+        min_severity="high",
+        enabled_scan_types=["sast"],
+    )
+    assert data["name"] == "SAST Policy"
+    assert data["action"] == "block"
+    assert data["min_severity"] == "high"
+    assert data["enabled_scan_types"] == ["sast"]
+    assert data["is_active"] is False
+    assert "id" in data
+
+
+async def test_create_policy_duplicate_name(client: AsyncClient):
+    name = f"Unique-{uuid.uuid4().hex[:6]}"
+    await _create_policy(client, name=name)
+    resp = await client.post(BASE, json={"name": name, "action": "inform", "min_severity": "low"})
+    assert resp.status_code == 409
+
+
+async def test_create_policy_invalid_action(client: AsyncClient):
+    resp = await client.post(BASE, json={"name": "Bad", "action": "explode", "min_severity": "low"})
+    assert resp.status_code == 422
+
+
+async def test_create_policy_invalid_severity(client: AsyncClient):
+    resp = await client.post(BASE, json={"name": "Bad2", "action": "inform", "min_severity": "extreme"})
+    assert resp.status_code == 422
+
+
+async def test_create_policy_invalid_scan_type(client: AsyncClient):
+    resp = await client.post(
+        BASE,
+        json={"name": "Bad3", "action": "inform", "min_severity": "low", "enabled_scan_types": ["unknown_type"]},
+    )
+    assert resp.status_code == 422
+
+
+async def test_get_policy(client: AsyncClient):
+    policy = await _create_policy(client, name=f"GetMe-{uuid.uuid4().hex[:6]}")
+    resp = await client.get(f"{BASE}/{policy['id']}")
+    assert resp.status_code == 200
+    assert resp.json()["id"] == policy["id"]
+
+
+async def test_get_policy_not_found(client: AsyncClient):
+    resp = await client.get(f"{BASE}/{uuid.uuid4()}")
+    assert resp.status_code == 404
+
+
+async def test_list_policies(client: AsyncClient):
+    await _create_policy(client)
+    resp = await client.get(BASE)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "items" in data
+    assert data["total"] >= 1
+
+
+async def test_list_policies_filter_active(client: AsyncClient):
+    await _create_policy(client, is_active=True, name=f"ActivePolicy-{uuid.uuid4().hex[:6]}")
+    resp = await client.get(f"{BASE}?is_active=true")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert all(p["is_active"] for p in data["items"])
+
+
+async def test_update_policy(client: AsyncClient):
+    policy = await _create_policy(client)
+    resp = await client.patch(f"{BASE}/{policy['id']}", json={"is_active": True, "min_severity": "critical"})
+    assert resp.status_code == 200
+    updated = resp.json()
+    assert updated["is_active"] is True
+    assert updated["min_severity"] == "critical"
+
+
+async def test_update_policy_name_conflict(client: AsyncClient):
+    p1 = await _create_policy(client, name=f"P1-{uuid.uuid4().hex[:6]}")
+    p2 = await _create_policy(client, name=f"P2-{uuid.uuid4().hex[:6]}")
+    resp = await client.patch(f"{BASE}/{p2['id']}", json={"name": p1["name"]})
+    assert resp.status_code == 409
+
+
+async def test_delete_policy(client: AsyncClient):
+    policy = await _create_policy(client)
+    resp = await client.delete(f"{BASE}/{policy['id']}")
+    assert resp.status_code == 204
+    resp2 = await client.get(f"{BASE}/{policy['id']}")
+    assert resp2.status_code == 404
+
+
+async def test_delete_policy_not_found(client: AsyncClient):
+    resp = await client.delete(f"{BASE}/{uuid.uuid4()}")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Policy evaluation logic
+# ---------------------------------------------------------------------------
+
+
+def _make_finding(**kwargs):
+    """Build a minimal mock Finding object for unit tests."""
+    from unittest.mock import MagicMock
+    f = MagicMock()
+    f.id = uuid.uuid4()
+    f.title = kwargs.get("title", "Test finding")
+    f.severity = kwargs.get("severity", "medium")
+    f.status = kwargs.get("status", "open")
+    f.scanner = kwargs.get("scanner", "semgrep")
+    f.finding_type = kwargs.get("finding_type", "SAST")
+    f.rule_id = kwargs.get("rule_id", None)
+    f.cve_id = kwargs.get("cve_id", None)
+    f.package_name = kwargs.get("package_name", None)
+    return f
+
+
+def _make_policy(**kwargs):
+    from unittest.mock import MagicMock
+    p = MagicMock()
+    p.id = uuid.uuid4()
+    p.name = kwargs.get("name", "Test Policy")
+    p.is_active = kwargs.get("is_active", True)
+    p.action = kwargs.get("action", "inform")
+    p.min_severity = kwargs.get("min_severity", "medium")
+    p.enabled_scan_types = kwargs.get("enabled_scan_types", [])
+    p.rule_blocklist = kwargs.get("rule_blocklist", [])
+    p.rule_allowlist = kwargs.get("rule_allowlist", [])
+    return p
+
+
+def test_evaluate_severity_threshold_flags_above():
+    from app.services.policy_evaluator import evaluate_policy
+    policy = _make_policy(min_severity="medium")
+    findings = [
+        _make_finding(severity="low"),      # below threshold — not flagged
+        _make_finding(severity="medium"),   # at threshold — flagged
+        _make_finding(severity="high"),     # above — flagged
+        _make_finding(severity="critical"), # above — flagged
+    ]
+    result = evaluate_policy(policy, findings)
+    assert result["total_violations"] == 3
+
+
+def test_evaluate_severity_threshold_info_catches_all():
+    from app.services.policy_evaluator import evaluate_policy
+    policy = _make_policy(min_severity="info")
+    findings = [_make_finding(severity=s) for s in ["info", "low", "medium", "high", "critical"]]
+    result = evaluate_policy(policy, findings)
+    assert result["total_violations"] == 5
+
+
+def test_evaluate_ignores_non_open_findings():
+    from app.services.policy_evaluator import evaluate_policy
+    policy = _make_policy(min_severity="low")
+    findings = [
+        _make_finding(severity="critical", status="fixed"),
+        _make_finding(severity="critical", status="accepted"),
+        _make_finding(severity="critical", status="open"),
+    ]
+    result = evaluate_policy(policy, findings)
+    assert result["total_violations"] == 1
+
+
+def test_evaluate_blocklist_overrides_severity():
+    from app.services.policy_evaluator import evaluate_policy
+    policy = _make_policy(min_severity="critical", rule_blocklist=["CVE-2024-1234"])
+    findings = [
+        _make_finding(severity="low", cve_id="CVE-2024-1234"),  # below threshold but blocklisted
+    ]
+    result = evaluate_policy(policy, findings)
+    assert result["total_violations"] == 1
+    assert result["violations"][0]["reason"] == "blocklisted_rule"
+
+
+def test_evaluate_allowlist_skips_finding():
+    from app.services.policy_evaluator import evaluate_policy
+    policy = _make_policy(min_severity="low", rule_allowlist=["python.lang.security.audit.dangerous-system-call"])
+    findings = [
+        _make_finding(severity="critical", rule_id="python.lang.security.audit.dangerous-system-call"),
+    ]
+    result = evaluate_policy(policy, findings)
+    assert result["total_violations"] == 0
+
+
+def test_evaluate_allowlist_beats_blocklist():
+    from app.services.policy_evaluator import evaluate_policy
+    policy = _make_policy(
+        min_severity="critical",
+        rule_blocklist=["CVE-2024-9999"],
+        rule_allowlist=["CVE-2024-9999"],
+    )
+    findings = [_make_finding(severity="low", cve_id="CVE-2024-9999")]
+    result = evaluate_policy(policy, findings)
+    assert result["total_violations"] == 0
+
+
+def test_evaluate_scan_type_filter():
+    from app.services.policy_evaluator import evaluate_policy
+    policy = _make_policy(min_severity="low", enabled_scan_types=["sast"])
+    findings = [
+        _make_finding(severity="critical", finding_type="SAST", scanner="semgrep"),   # included
+        _make_finding(severity="critical", finding_type="container", scanner="grype"), # excluded
+        _make_finding(severity="critical", finding_type="SCA", scanner="trivy"),       # excluded
+    ]
+    result = evaluate_policy(policy, findings)
+    assert result["total_violations"] == 1
+
+
+def test_evaluate_empty_scan_types_applies_to_all():
+    from app.services.policy_evaluator import evaluate_policy
+    policy = _make_policy(min_severity="low", enabled_scan_types=[])
+    findings = [
+        _make_finding(severity="high", finding_type="SAST", scanner="semgrep"),
+        _make_finding(severity="high", finding_type="container", scanner="grype"),
+        _make_finding(severity="high", finding_type="SCA", scanner="trivy"),
+    ]
+    result = evaluate_policy(policy, findings)
+    assert result["total_violations"] == 3
+
+
+def test_evaluate_action_block_sets_blocked():
+    from app.services.policy_evaluator import evaluate_policy
+    policy = _make_policy(min_severity="low", action="block")
+    findings = [_make_finding(severity="high")]
+    result = evaluate_policy(policy, findings)
+    assert result["blocked"] is True
+
+
+def test_evaluate_action_inform_does_not_block():
+    from app.services.policy_evaluator import evaluate_policy
+    policy = _make_policy(min_severity="low", action="inform")
+    findings = [_make_finding(severity="high")]
+    result = evaluate_policy(policy, findings)
+    assert result["blocked"] is False
+
+
+def test_evaluate_action_both_blocks():
+    from app.services.policy_evaluator import evaluate_policy
+    policy = _make_policy(min_severity="low", action="both")
+    findings = [_make_finding(severity="high")]
+    result = evaluate_policy(policy, findings)
+    assert result["blocked"] is True
+
+
+def test_evaluate_no_violations_never_blocks():
+    from app.services.policy_evaluator import evaluate_policy
+    policy = _make_policy(min_severity="critical", action="block")
+    findings = [_make_finding(severity="low")]
+    result = evaluate_policy(policy, findings)
+    assert result["blocked"] is False
+    assert result["total_violations"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Evaluate API endpoints
+# ---------------------------------------------------------------------------
+
+
+async def test_evaluate_policy_endpoint(client: AsyncClient):
+    policy = await _create_policy(client, is_active=True, min_severity="low")
+    resp = await client.post(f"{BASE}/{policy['id']}/evaluate")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "total_violations" in data
+    assert "violations" in data
+    assert data["policy_id"] == policy["id"]
+
+
+async def test_evaluate_all_active_endpoint(client: AsyncClient):
+    await _create_policy(client, is_active=True, name=f"ActiveEval-{uuid.uuid4().hex[:6]}")
+    resp = await client.get(f"{BASE}/evaluate/all")
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)
+
+
+# ---------------------------------------------------------------------------
+# Seed endpoint
+# ---------------------------------------------------------------------------
+
+
+async def test_seed_creates_default_policies(client: AsyncClient):
+    resp = await client.post(f"{BASE}/seed")
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["policies_created"] == 5
+
+
+async def test_seed_idempotent(client: AsyncClient):
+    resp1 = await client.post(f"{BASE}/seed")
+    assert resp1.status_code == 201
+    assert resp1.json()["policies_created"] == 5
+
+    resp2 = await client.post(f"{BASE}/seed")
+    assert resp2.status_code == 201
+    assert resp2.json()["policies_created"] == 0
+
+
+async def test_seed_policy_names(client: AsyncClient):
+    await client.post(f"{BASE}/seed")
+    resp = await client.get(BASE, params={"page_size": 20})
+    assert resp.status_code == 200
+    names = {p["name"] for p in resp.json()["items"]}
+    assert "Baseline SAST Policy" in names
+    assert "Critical Vulnerability Block" in names
+    assert "Secrets Detection" in names
+    assert "IaC Security (CIS Level 1)" in names
+
+
+async def test_seed_iac_policy_has_cis_rules(client: AsyncClient):
+    await client.post(f"{BASE}/seed")
+    resp = await client.get(BASE, params={"page_size": 20})
+    policies = resp.json()["items"]
+    iac_policy = next(p for p in policies if p["name"] == "IaC Security (CIS Level 1)")
+    blocklist = iac_policy["rule_blocklist"]
+    assert "CKV_AWS_1" in blocklist
+    assert "CKV_AWS_24" in blocklist
+    assert "CKV_AWS_20" in blocklist
+    assert len(blocklist) >= 10
+
+
+async def test_seed_all_policies_active(client: AsyncClient):
+    await client.post(f"{BASE}/seed")
+    resp = await client.get(BASE, params={"is_active": "true", "page_size": 20})
+    assert resp.json()["total"] == 5

--- a/backend/tests/test_secrets.py
+++ b/backend/tests/test_secrets.py
@@ -1,0 +1,357 @@
+"""Tests for the Secrets findings and custom pattern API."""
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+BASE = "/api/v1/secrets"
+FINDINGS_BASE = f"{BASE}/findings"
+PATTERNS_BASE = f"{BASE}/patterns"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _create_application(client: AsyncClient) -> dict:
+    name = f"TestApp-{uuid.uuid4().hex[:6]}"
+    resp = await client.post(
+        "/api/v1/applications",
+        json={
+            "name": name,
+            "github_org": "test-org",
+            "github_repo": name.lower(),
+            "repo_url": "https://github.com/test-org/repo",
+            "team_name": "security",
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+async def _insert_finding(db: AsyncSession, application_id, **overrides):
+    from app.models.finding import Finding
+
+    finding = Finding(
+        application_id=application_id,
+        title=overrides.get("title", f"Secret {uuid.uuid4().hex[:6]}"),
+        description=overrides.get("description", "AWS key ****1234"),
+        severity=overrides.get("severity", "high"),
+        status=overrides.get("status", "open"),
+        finding_type=overrides.get("finding_type", "secrets"),
+        scanner=overrides.get("scanner", "gitleaks"),
+        rule_id=overrides.get("rule_id", f"aws-key-{uuid.uuid4().hex[:4]}"),
+        file_path=overrides.get("file_path", "src/config.py"),
+    )
+    db.add(finding)
+    await db.flush()
+    await db.refresh(finding)
+    return finding
+
+
+async def _create_pattern(client: AsyncClient, **overrides) -> dict:
+    payload = {
+        "name": f"Pattern-{uuid.uuid4().hex[:6]}",
+        "pattern": r"MYKEY-[A-Z0-9]{32}",
+        "severity": "high",
+        **overrides,
+    }
+    resp = await client.post(PATTERNS_BASE, json=payload)
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# Findings — list
+# ---------------------------------------------------------------------------
+
+
+async def test_list_findings_empty(client: AsyncClient):
+    resp = await client.get(FINDINGS_BASE)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "items" in data
+    assert "total" in data
+
+
+async def test_list_findings_returns_only_secrets_type(client: AsyncClient, db_session: AsyncSession):
+    app = await _create_application(client)
+    app_id = uuid.UUID(app["id"])
+    await _insert_finding(db_session, app_id, finding_type="secrets")
+    await _insert_finding(db_session, app_id, finding_type="SAST")
+
+    resp = await client.get(FINDINGS_BASE)
+    assert resp.status_code == 200
+    assert all(f["finding_type"] == "secrets" for f in resp.json()["items"])
+
+
+async def test_list_findings_filter_by_application(client: AsyncClient, db_session: AsyncSession):
+    app1 = await _create_application(client)
+    app2 = await _create_application(client)
+    await _insert_finding(db_session, uuid.UUID(app1["id"]))
+    await _insert_finding(db_session, uuid.UUID(app2["id"]))
+
+    resp = await client.get(FINDINGS_BASE, params={"application_id": app1["id"]})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] >= 1
+    assert all(f["application_id"] == app1["id"] for f in data["items"])
+
+
+async def test_list_findings_filter_by_severity(client: AsyncClient, db_session: AsyncSession):
+    app = await _create_application(client)
+    app_id = uuid.UUID(app["id"])
+    await _insert_finding(db_session, app_id, severity="critical")
+    await _insert_finding(db_session, app_id, severity="low")
+
+    resp = await client.get(FINDINGS_BASE, params={"application_id": app["id"], "severity": "critical"})
+    assert resp.status_code == 200
+    assert all(f["severity"] == "critical" for f in resp.json()["items"])
+
+
+async def test_list_findings_filter_by_status(client: AsyncClient, db_session: AsyncSession):
+    app = await _create_application(client)
+    app_id = uuid.UUID(app["id"])
+    await _insert_finding(db_session, app_id, status="open")
+    await _insert_finding(db_session, app_id, status="accepted")
+
+    resp = await client.get(FINDINGS_BASE, params={"application_id": app["id"], "status": "accepted"})
+    assert resp.status_code == 200
+    assert all(f["status"] == "accepted" for f in resp.json()["items"])
+
+
+# ---------------------------------------------------------------------------
+# Findings — get
+# ---------------------------------------------------------------------------
+
+
+async def test_get_finding(client: AsyncClient, db_session: AsyncSession):
+    app = await _create_application(client)
+    finding = await _insert_finding(db_session, uuid.UUID(app["id"]))
+    resp = await client.get(f"{FINDINGS_BASE}/{finding.id}")
+    assert resp.status_code == 200
+    assert resp.json()["id"] == str(finding.id)
+
+
+async def test_get_finding_not_found(client: AsyncClient):
+    resp = await client.get(f"{FINDINGS_BASE}/{uuid.uuid4()}")
+    assert resp.status_code == 404
+
+
+async def test_get_finding_wrong_type_returns_404(client: AsyncClient, db_session: AsyncSession):
+    app = await _create_application(client)
+    finding = await _insert_finding(db_session, uuid.UUID(app["id"]), finding_type="SAST")
+    resp = await client.get(f"{FINDINGS_BASE}/{finding.id}")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Findings — patch
+# ---------------------------------------------------------------------------
+
+
+async def test_patch_finding_status(client: AsyncClient, db_session: AsyncSession):
+    app = await _create_application(client)
+    finding = await _insert_finding(db_session, uuid.UUID(app["id"]), status="open")
+    resp = await client.patch(f"{FINDINGS_BASE}/{finding.id}", json={"status": "accepted"})
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "accepted"
+
+
+async def test_patch_finding_not_found(client: AsyncClient):
+    resp = await client.patch(f"{FINDINGS_BASE}/{uuid.uuid4()}", json={"status": "accepted"})
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Findings — stats
+# ---------------------------------------------------------------------------
+
+
+async def test_stats_returns_expected_fields(client: AsyncClient):
+    resp = await client.get(f"{FINDINGS_BASE}/stats")
+    assert resp.status_code == 200
+    data = resp.json()
+    for key in ("total", "critical", "high", "medium", "low", "open", "accepted", "false_positive", "by_rule"):
+        assert key in data, f"missing key: {key}"
+
+
+async def test_stats_counts_by_severity(client: AsyncClient, db_session: AsyncSession):
+    app = await _create_application(client)
+    app_id = uuid.UUID(app["id"])
+    await _insert_finding(db_session, app_id, severity="critical")
+    await _insert_finding(db_session, app_id, severity="critical")
+    await _insert_finding(db_session, app_id, severity="medium")
+
+    resp = await client.get(f"{FINDINGS_BASE}/stats", params={"application_id": app["id"]})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["critical"] == 2
+    assert data["medium"] == 1
+    assert data["total"] == 3
+
+
+async def test_stats_filter_by_application(client: AsyncClient, db_session: AsyncSession):
+    app1 = await _create_application(client)
+    app2 = await _create_application(client)
+    await _insert_finding(db_session, uuid.UUID(app1["id"]), severity="high")
+    await _insert_finding(db_session, uuid.UUID(app2["id"]), severity="critical")
+
+    resp = await client.get(f"{FINDINGS_BASE}/stats", params={"application_id": app1["id"]})
+    data = resp.json()
+    assert data["total"] == 1
+    assert data["high"] == 1
+    assert data["critical"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Patterns — list
+# ---------------------------------------------------------------------------
+
+
+async def test_list_patterns_empty(client: AsyncClient):
+    resp = await client.get(PATTERNS_BASE)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "items" in data
+    assert "total" in data
+
+
+async def test_list_patterns_with_data(client: AsyncClient):
+    await _create_pattern(client)
+    resp = await client.get(PATTERNS_BASE)
+    assert resp.status_code == 200
+    assert resp.json()["total"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# Patterns — create
+# ---------------------------------------------------------------------------
+
+
+async def test_create_pattern(client: AsyncClient):
+    data = await _create_pattern(client, name=f"MyPattern-{uuid.uuid4().hex[:6]}", severity="critical")
+    assert data["severity"] == "critical"
+    assert data["is_active"] is True
+    assert "id" in data
+
+
+async def test_create_pattern_invalid_regex(client: AsyncClient):
+    resp = await client.post(PATTERNS_BASE, json={"name": "Bad", "pattern": "[invalid(", "severity": "high"})
+    assert resp.status_code == 422
+
+
+async def test_create_pattern_invalid_severity(client: AsyncClient):
+    resp = await client.post(PATTERNS_BASE, json={"name": "Bad2", "pattern": r"\d+", "severity": "extreme"})
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Patterns — get
+# ---------------------------------------------------------------------------
+
+
+async def test_get_pattern(client: AsyncClient):
+    pattern = await _create_pattern(client)
+    resp = await client.get(f"{PATTERNS_BASE}/{pattern['id']}")
+    assert resp.status_code == 200
+    assert resp.json()["id"] == pattern["id"]
+
+
+async def test_get_pattern_not_found(client: AsyncClient):
+    resp = await client.get(f"{PATTERNS_BASE}/{uuid.uuid4()}")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Patterns — update
+# ---------------------------------------------------------------------------
+
+
+async def test_update_pattern(client: AsyncClient):
+    pattern = await _create_pattern(client)
+    resp = await client.put(
+        f"{PATTERNS_BASE}/{pattern['id']}",
+        json={"name": pattern["name"], "pattern": r"\d{16}", "severity": "critical", "is_active": False},
+    )
+    assert resp.status_code == 200
+    updated = resp.json()
+    assert updated["severity"] == "critical"
+    assert updated["is_active"] is False
+
+
+async def test_update_pattern_invalid_regex(client: AsyncClient):
+    pattern = await _create_pattern(client)
+    resp = await client.put(
+        f"{PATTERNS_BASE}/{pattern['id']}",
+        json={"name": pattern["name"], "pattern": "[broken(", "severity": "high"},
+    )
+    assert resp.status_code == 422
+
+
+async def test_update_pattern_not_found(client: AsyncClient):
+    resp = await client.put(
+        f"{PATTERNS_BASE}/{uuid.uuid4()}",
+        json={"name": "x", "pattern": r"\d+", "severity": "low"},
+    )
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Patterns — delete
+# ---------------------------------------------------------------------------
+
+
+async def test_delete_pattern(client: AsyncClient):
+    pattern = await _create_pattern(client)
+    resp = await client.delete(f"{PATTERNS_BASE}/{pattern['id']}")
+    assert resp.status_code == 204
+    resp2 = await client.get(f"{PATTERNS_BASE}/{pattern['id']}")
+    assert resp2.status_code == 404
+
+
+async def test_delete_pattern_not_found(client: AsyncClient):
+    resp = await client.delete(f"{PATTERNS_BASE}/{uuid.uuid4()}")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Patterns — test regex
+# ---------------------------------------------------------------------------
+
+
+async def test_pattern_test_valid_with_matches(client: AsyncClient):
+    resp = await client.post(
+        f"{PATTERNS_BASE}/test",
+        json={"pattern": r"MYKEY-[A-Z0-9]{32}", "sample_text": "found MYKEY-ABCDEFGHIJKLMNOPQRSTUVWXYZ012345 here"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["valid"] is True
+    assert data["match_count"] == 1
+    assert len(data["matches"]) == 1
+
+
+async def test_pattern_test_valid_no_matches(client: AsyncClient):
+    resp = await client.post(
+        f"{PATTERNS_BASE}/test",
+        json={"pattern": r"SECRET-\d{10}", "sample_text": "nothing to see here"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["valid"] is True
+    assert data["match_count"] == 0
+
+
+async def test_pattern_test_invalid_regex(client: AsyncClient):
+    resp = await client.post(
+        f"{PATTERNS_BASE}/test",
+        json={"pattern": "[invalid(", "sample_text": "any text"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["valid"] is False
+    assert data["match_count"] == 0
+    assert data["error"] is not None

--- a/frontend/app-detail.html
+++ b/frontend/app-detail.html
@@ -72,6 +72,12 @@
       <a href="/reports.html" class="nav-link" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;color:#94a3b8;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;">
         <i data-lucide="bar-chart-3" style="width:18px;height:18px;"></i> Reports
       </a>
+      <a href="/policies.html" class="nav-link" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;color:#94a3b8;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;">
+        <i data-lucide="shield-check" style="width:18px;height:18px;"></i> Policies
+      </a>
+      <a href="/secrets.html" class="nav-link" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;color:#94a3b8;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;">
+        <i data-lucide="key" style="width:18px;height:18px;"></i> Secrets
+      </a>
       <div style="font-size:10px;color:#475569;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;padding:16px 8px 4px;">Developer</div>
       <a href="/docs" class="nav-link" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;color:#94a3b8;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;">
         <i data-lucide="code-2" style="width:18px;height:18px;"></i> API Docs

--- a/frontend/applications.html
+++ b/frontend/applications.html
@@ -62,6 +62,12 @@
       <a href="/reports.html" class="nav-link" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;color:#94a3b8;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;">
         <i data-lucide="bar-chart-3" style="width:18px;height:18px;"></i> Reports
       </a>
+      <a href="/policies.html" class="nav-link" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;color:#94a3b8;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;">
+        <i data-lucide="shield-check" style="width:18px;height:18px;"></i> Policies
+      </a>
+      <a href="/secrets.html" class="nav-link" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;color:#94a3b8;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;">
+        <i data-lucide="key" style="width:18px;height:18px;"></i> Secrets
+      </a>
       <div style="font-size:10px;color:#475569;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;padding:16px 8px 4px;">Developer</div>
       <a href="/docs" class="nav-link" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;color:#94a3b8;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;">
         <i data-lucide="code-2" style="width:18px;height:18px;"></i> API Docs

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -56,6 +56,12 @@
       <a href="/reports.html" class="nav-link" id="nav-reports" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;color:#94a3b8;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;">
         <i data-lucide="bar-chart-3" style="width:18px;height:18px;"></i> Reports
       </a>
+      <a href="/policies.html" class="nav-link" id="nav-policies" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;color:#94a3b8;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;">
+        <i data-lucide="shield-check" style="width:18px;height:18px;"></i> Policies
+      </a>
+      <a href="/secrets.html" class="nav-link" id="nav-secrets" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;color:#94a3b8;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;">
+        <i data-lucide="key" style="width:18px;height:18px;"></i> Secrets
+      </a>
       <div style="font-size:10px;color:#475569;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;padding:16px 8px 4px;">Developer</div>
       <a href="/docs" class="nav-link" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;color:#94a3b8;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;">
         <i data-lucide="code-2" style="width:18px;height:18px;"></i> API Docs
@@ -77,9 +83,6 @@
         <h1 style="font-size:22px;font-weight:700;color:#f1f5f9;margin:0;">Security Overview</h1>
         <p style="font-size:13px;color:#475569;margin:2px 0 0;">Real-time application security monitoring</p>
       </div>
-      <button class="btn-primary" onclick="seedDemo()" id="seed-btn">
-        <i data-lucide="database" style="width:16px;height:16px;"></i> Seed Demo Data
-      </button>
     </header>
 
     <main style="padding:32px;">
@@ -237,23 +240,6 @@ function showToast(message, type='success') {
   setTimeout(() => { toast.style.animation='slideOutRight 0.3s ease forwards'; setTimeout(()=>toast.remove(),300); }, 3500);
 }
 
-// ── Seed Demo Data ─────────────────────────────────────────────────────────────
-async function seedDemo() {
-  const btn = document.getElementById('seed-btn');
-  btn.disabled = true;
-  btn.innerHTML = '<div style="animation:spin 1s linear infinite;display:inline-block;width:16px;height:16px;border:2px solid rgba(255,255,255,0.3);border-top-color:white;border-radius:50%;"></div> Seeding...';
-  try {
-    const res = await fetch('/api/v1/seed', { method:'POST' });
-    if (!res.ok) throw new Error('Seed failed');
-    showToast('Demo data seeded successfully!', 'success');
-    setTimeout(() => location.reload(), 1000);
-  } catch(e) {
-    showToast('Failed to seed demo data: ' + e.message, 'error');
-    btn.disabled = false;
-    btn.innerHTML = '<i data-lucide="database" style="width:16px;height:16px;"></i> Seed Demo Data';
-    lucide.createIcons();
-  }
-}
 
 // ── Charts ─────────────────────────────────────────────────────────────────────
 let severityChartInst, riskChartInst;

--- a/frontend/policies.html
+++ b/frontend/policies.html
@@ -1,0 +1,661 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Snitch — Security Policies</title>
+  <style>/* Inter font fallback */ body { font-family: "Inter", system-ui, -apple-system, sans-serif; }</style>
+  <script src="/static/js/lucide.min.js"></script>
+  <style>
+    * { box-sizing: border-box; }
+    @keyframes fadeInUp { from{transform:translateY(20px);opacity:0} to{transform:translateY(0);opacity:1} }
+    @keyframes pulse { 0%,100%{opacity:1} 50%{opacity:0.5} }
+    @keyframes slideInRight { from{transform:translateX(100%);opacity:0} to{transform:translateX(0);opacity:1} }
+    .nav-link:hover { background:rgba(255,255,255,0.05) !important; color:#e2e8f0 !important; }
+    .btn-primary { background:linear-gradient(135deg,#00d4ff,#6366f1);color:white;border:none;padding:10px 20px;border-radius:10px;font-weight:600;font-size:14px;cursor:pointer;transition:all 0.2s;display:inline-flex;align-items:center;gap:8px; }
+    .btn-primary:hover { transform:translateY(-1px);box-shadow:0 4px 20px rgba(0,212,255,0.4); }
+    .btn-secondary { background:rgba(255,255,255,0.05);color:#94a3b8;border:1px solid rgba(255,255,255,0.1);padding:8px 16px;border-radius:8px;font-weight:500;font-size:13px;cursor:pointer;transition:all 0.2s; }
+    .btn-secondary:hover { background:rgba(255,255,255,0.1);color:#f1f5f9; }
+    .btn-danger { background:rgba(239,68,68,0.1);color:#f87171;border:1px solid rgba(239,68,68,0.2);padding:8px 16px;border-radius:8px;font-weight:500;font-size:13px;cursor:pointer;transition:all 0.2s; }
+    .btn-danger:hover { background:rgba(239,68,68,0.2); }
+    .btn-icon { background:none;border:none;cursor:pointer;padding:6px;border-radius:6px;transition:all 0.2s;display:inline-flex;align-items:center;justify-content:center; }
+    .btn-icon:hover { background:rgba(255,255,255,0.08); }
+    .card { background:rgba(13,17,23,0.8);border:1px solid rgba(255,255,255,0.08);border-radius:16px;backdrop-filter:blur(20px); }
+    .dark-input { background:rgba(255,255,255,0.05);border:1px solid rgba(255,255,255,0.1);border-radius:8px;color:#f1f5f9;font-size:14px;padding:8px 12px;outline:none;transition:border 0.2s;font-family:'Inter',sans-serif;width:100%; }
+    .dark-input:focus { border-color:rgba(0,212,255,0.5); }
+    .dark-input::placeholder { color:#475569; }
+    .dark-select { background:#0d1117;border:1px solid rgba(255,255,255,0.1);border-radius:8px;color:#f1f5f9;font-size:14px;padding:8px 12px;outline:none;cursor:pointer;font-family:'Inter',sans-serif;width:100%; }
+    .dark-select:focus { border-color:rgba(0,212,255,0.5); }
+    .dark-select option { background:#0d1117; }
+    ::-webkit-scrollbar { width:6px;height:6px; }
+    ::-webkit-scrollbar-track { background:rgba(255,255,255,0.02); }
+    ::-webkit-scrollbar-thumb { background:rgba(255,255,255,0.1);border-radius:3px; }
+    .modal-backdrop { position:fixed;inset:0;background:rgba(0,0,0,0.7);backdrop-filter:blur(8px);z-index:200;display:flex;align-items:center;justify-content:center; }
+    .policy-row:hover { background:rgba(255,255,255,0.03); }
+    .tag { display:inline-flex;align-items:center;padding:2px 8px;border-radius:20px;font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:0.5px; }
+    .tag-sast { background:rgba(99,102,241,0.2);color:#a5b4fc; }
+    .tag-sca { background:rgba(16,185,129,0.2);color:#6ee7b7; }
+    .tag-container { background:rgba(245,158,11,0.2);color:#fcd34d; }
+    .tag-secrets { background:rgba(239,68,68,0.2);color:#fca5a5; }
+    .tag-iac { background:rgba(168,85,247,0.2);color:#d8b4fe; }
+    .tag-block { background:rgba(239,68,68,0.15);color:#f87171; }
+    .tag-inform { background:rgba(59,130,246,0.15);color:#93c5fd; }
+    .tag-both { background:rgba(245,158,11,0.15);color:#fcd34d; }
+    .sev-critical { color:#ef4444; }
+    .sev-high { color:#f97316; }
+    .sev-medium { color:#eab308; }
+    .sev-low { color:#22c55e; }
+    .sev-info { color:#64748b; }
+    .chip { display:inline-flex;align-items:center;gap:4px;padding:3px 10px;border-radius:20px;font-size:12px;font-weight:500;background:rgba(255,255,255,0.07);color:#94a3b8;cursor:pointer;transition:all 0.15s;user-select:none;border:1px solid transparent; }
+    .chip.active { border-color:rgba(0,212,255,0.4);color:#00d4ff;background:rgba(0,212,255,0.1); }
+    .chip:hover:not(.active) { background:rgba(255,255,255,0.1); }
+    .drawer { position:fixed;top:0;right:0;height:100vh;width:480px;background:#080c18;border-left:1px solid rgba(255,255,255,0.08);z-index:300;overflow-y:auto;animation:slideInRight 0.25s ease; }
+    .toggle-switch { position:relative;display:inline-block;width:36px;height:20px; }
+    .toggle-switch input { opacity:0;width:0;height:0; }
+    .slider { position:absolute;cursor:pointer;inset:0;background:rgba(255,255,255,0.1);border-radius:20px;transition:0.3s; }
+    .slider:before { position:absolute;content:"";height:14px;width:14px;left:3px;bottom:3px;background:white;border-radius:50%;transition:0.3s; }
+    input:checked + .slider { background:linear-gradient(135deg,#00d4ff,#6366f1); }
+    input:checked + .slider:before { transform:translateX(16px); }
+  </style>
+</head>
+<body style="font-family:'Inter',sans-serif;background:#0a0e1a;color:#f1f5f9;margin:0;padding:0;min-height:100vh;">
+
+  <!-- Sidebar -->
+  <aside style="width:260px;min-height:100vh;background:#080c18;border-right:1px solid rgba(255,255,255,0.08);display:flex;flex-direction:column;position:fixed;left:0;top:0;z-index:100;">
+    <div style="padding:24px 20px;border-bottom:1px solid rgba(255,255,255,0.08);display:flex;align-items:center;gap:12px;">
+      <div style="width:40px;height:40px;background:linear-gradient(135deg,#00d4ff22,#6366f122);border:1px solid #00d4ff44;border-radius:12px;display:flex;align-items:center;justify-content:center;">
+        <i data-lucide="shield-alert" style="width:20px;height:20px;color:#00d4ff;"></i>
+      </div>
+      <div>
+        <div style="font-size:20px;font-weight:800;color:#f1f5f9;letter-spacing:-0.5px;">Snitch</div>
+        <div style="font-size:11px;color:#00d4ff;font-weight:500;letter-spacing:1px;text-transform:uppercase;">AppSec Platform</div>
+      </div>
+    </div>
+    <nav style="flex:1;padding:16px 12px;">
+      <div style="font-size:10px;color:#475569;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;padding:8px 8px 4px;">Main Menu</div>
+      <a href="/" class="nav-link" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;color:#94a3b8;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;">
+        <i data-lucide="layout-dashboard" style="width:18px;height:18px;"></i> Dashboard
+      </a>
+      <a href="/applications.html" class="nav-link" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;color:#94a3b8;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;">
+        <i data-lucide="layers" style="width:18px;height:18px;"></i> Applications
+      </a>
+      <a href="/repositories.html" class="nav-link" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;color:#94a3b8;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;">
+        <i data-lucide="git-branch" style="width:18px;height:18px;"></i> Repositories
+      </a>
+      <a href="/reports.html" class="nav-link" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;color:#94a3b8;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;">
+        <i data-lucide="bar-chart-3" style="width:18px;height:18px;"></i> Reports
+      </a>
+      <a href="/policies.html" class="nav-link" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;background:linear-gradient(135deg,rgba(0,212,255,0.15),rgba(99,102,241,0.15));color:#00d4ff;border:1px solid rgba(0,212,255,0.2);">
+        <i data-lucide="shield-check" style="width:18px;height:18px;"></i> Policies
+      </a>
+      <a href="/secrets.html" class="nav-link" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;color:#94a3b8;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;">
+        <i data-lucide="key" style="width:18px;height:18px;"></i> Secrets
+      </a>
+      <div style="font-size:10px;color:#475569;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;padding:16px 8px 4px;">Developer</div>
+      <a href="/docs" class="nav-link" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;color:#94a3b8;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;">
+        <i data-lucide="code-2" style="width:18px;height:18px;"></i> API Docs
+        <i data-lucide="external-link" style="width:12px;height:12px;margin-left:auto;"></i>
+      </a>
+    </nav>
+    <div style="padding:16px 20px;border-top:1px solid rgba(255,255,255,0.08);">
+      <div style="display:flex;align-items:center;gap:8px;">
+        <div style="width:8px;height:8px;background:#10b981;border-radius:50%;box-shadow:0 0 8px #10b981;"></div>
+        <span style="font-size:12px;color:#475569;">All systems operational</span>
+      </div>
+    </div>
+  </aside>
+
+  <!-- Main -->
+  <div style="margin-left:260px;min-height:100vh;">
+    <header style="background:rgba(8,12,24,0.9);backdrop-filter:blur(20px);border-bottom:1px solid rgba(255,255,255,0.08);padding:16px 32px;display:flex;align-items:center;justify-content:space-between;position:sticky;top:0;z-index:50;">
+      <div>
+        <h1 style="font-size:22px;font-weight:700;color:#f1f5f9;margin:0;">Security Policies</h1>
+        <p style="font-size:13px;color:#475569;margin:2px 0 0;">Define scan rules, severity thresholds, and enforcement actions</p>
+      </div>
+      <div style="display:flex;gap:10px;align-items:center;">
+        <button class="btn-secondary" onclick="seedDefaultPolicies()" id="seed-btn" title="Create default CIS L1-aligned policies">
+          <i data-lucide="database" style="width:14px;height:14px;display:inline-block;vertical-align:middle;margin-right:4px;"></i> Seed Defaults
+        </button>
+        <button class="btn-secondary" onclick="evaluateAll()" id="eval-all-btn">
+          <i data-lucide="play" style="width:14px;height:14px;display:inline-block;vertical-align:middle;margin-right:4px;"></i> Run All Active
+        </button>
+        <button class="btn-primary" onclick="openModal()">
+          <i data-lucide="plus" style="width:16px;height:16px;"></i> New Policy
+        </button>
+      </div>
+    </header>
+
+    <main style="padding:32px;">
+
+      <!-- Summary Cards -->
+      <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:20px;margin-bottom:28px;" id="summary-cards">
+        <div class="card" style="padding:20px;animation:pulse 1.5s infinite;"><div style="height:14px;background:rgba(255,255,255,0.05);border-radius:6px;width:50%;margin-bottom:10px;"></div><div style="height:32px;background:rgba(255,255,255,0.05);border-radius:6px;width:40%;"></div></div>
+        <div class="card" style="padding:20px;animation:pulse 1.5s infinite;"><div style="height:14px;background:rgba(255,255,255,0.05);border-radius:6px;width:50%;margin-bottom:10px;"></div><div style="height:32px;background:rgba(255,255,255,0.05);border-radius:6px;width:40%;"></div></div>
+        <div class="card" style="padding:20px;animation:pulse 1.5s infinite;"><div style="height:14px;background:rgba(255,255,255,0.05);border-radius:6px;width:50%;margin-bottom:10px;"></div><div style="height:32px;background:rgba(255,255,255,0.05);border-radius:6px;width:40%;"></div></div>
+      </div>
+
+      <!-- Policy Table -->
+      <div class="card" style="overflow:hidden;">
+        <div style="padding:20px 24px;border-bottom:1px solid rgba(255,255,255,0.06);display:flex;align-items:center;justify-content:space-between;">
+          <div style="font-size:16px;font-weight:600;color:#f1f5f9;">All Policies</div>
+          <div style="display:flex;gap:8px;">
+            <select class="dark-select" id="filter-active" onchange="loadPolicies()" style="width:auto;padding:6px 10px;font-size:13px;">
+              <option value="">All</option>
+              <option value="true">Active only</option>
+              <option value="false">Inactive only</option>
+            </select>
+          </div>
+        </div>
+        <div id="policy-table-body">
+          <div style="padding:40px;text-align:center;color:#475569;animation:pulse 1.5s infinite;">Loading policies…</div>
+        </div>
+        <div id="pagination" style="padding:16px 24px;border-top:1px solid rgba(255,255,255,0.06);display:flex;align-items:center;justify-content:space-between;display:none;">
+          <span id="page-info" style="font-size:13px;color:#475569;"></span>
+          <div style="display:flex;gap:8px;">
+            <button class="btn-secondary" id="prev-btn" onclick="changePage(-1)" style="padding:6px 12px;">← Prev</button>
+            <button class="btn-secondary" id="next-btn" onclick="changePage(1)" style="padding:6px 12px;">Next →</button>
+          </div>
+        </div>
+      </div>
+
+    </main>
+  </div>
+
+  <!-- ===================== CREATE/EDIT MODAL ===================== -->
+  <div id="modal" class="modal-backdrop" style="display:none;" onclick="closeModalOnBackdrop(event)">
+    <div style="background:#0d1117;border:1px solid rgba(255,255,255,0.1);border-radius:20px;width:580px;max-height:90vh;overflow-y:auto;padding:32px;animation:fadeInUp 0.25s ease;" onclick="event.stopPropagation()">
+      <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:24px;">
+        <h2 id="modal-title" style="font-size:18px;font-weight:700;color:#f1f5f9;margin:0;">New Policy</h2>
+        <button class="btn-icon" onclick="closeModal()"><i data-lucide="x" style="width:18px;height:18px;color:#64748b;"></i></button>
+      </div>
+
+      <form id="policy-form" onsubmit="submitPolicy(event)">
+        <input type="hidden" id="edit-id">
+
+        <!-- Name -->
+        <div style="margin-bottom:16px;">
+          <label style="font-size:12px;font-weight:600;color:#94a3b8;text-transform:uppercase;letter-spacing:0.5px;display:block;margin-bottom:6px;">Policy Name *</label>
+          <input id="f-name" class="dark-input" type="text" required placeholder="e.g. SAST High Severity Policy">
+        </div>
+
+        <!-- Description -->
+        <div style="margin-bottom:16px;">
+          <label style="font-size:12px;font-weight:600;color:#94a3b8;text-transform:uppercase;letter-spacing:0.5px;display:block;margin-bottom:6px;">Description</label>
+          <textarea id="f-desc" class="dark-input" rows="2" placeholder="Optional description…" style="resize:vertical;"></textarea>
+        </div>
+
+        <!-- Scan Types -->
+        <div style="margin-bottom:16px;">
+          <label style="font-size:12px;font-weight:600;color:#94a3b8;text-transform:uppercase;letter-spacing:0.5px;display:block;margin-bottom:8px;">Scan Types <span style="font-weight:400;color:#475569;">(empty = all)</span></label>
+          <div style="display:flex;gap:8px;flex-wrap:wrap;" id="scan-type-chips">
+            <div class="chip" data-type="sast" onclick="toggleChip(this)"><i data-lucide="code" style="width:12px;height:12px;"></i> SAST</div>
+            <div class="chip" data-type="sca" onclick="toggleChip(this)"><i data-lucide="package" style="width:12px;height:12px;"></i> SCA</div>
+            <div class="chip" data-type="container" onclick="toggleChip(this)"><i data-lucide="box" style="width:12px;height:12px;"></i> Container</div>
+            <div class="chip" data-type="secrets" onclick="toggleChip(this)"><i data-lucide="key" style="width:12px;height:12px;"></i> Secrets</div>
+            <div class="chip" data-type="iac" onclick="toggleChip(this)"><i data-lucide="server" style="width:12px;height:12px;"></i> IaC</div>
+          </div>
+        </div>
+
+        <!-- Min Severity + Action -->
+        <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-bottom:16px;">
+          <div>
+            <label style="font-size:12px;font-weight:600;color:#94a3b8;text-transform:uppercase;letter-spacing:0.5px;display:block;margin-bottom:6px;">Min Severity</label>
+            <select id="f-severity" class="dark-select">
+              <option value="critical">Critical</option>
+              <option value="high">High</option>
+              <option value="medium" selected>Medium</option>
+              <option value="low">Low</option>
+              <option value="info">Info (all)</option>
+            </select>
+          </div>
+          <div>
+            <label style="font-size:12px;font-weight:600;color:#94a3b8;text-transform:uppercase;letter-spacing:0.5px;display:block;margin-bottom:6px;">Action on Violation</label>
+            <select id="f-action" class="dark-select">
+              <option value="inform">Inform</option>
+              <option value="block">Block</option>
+              <option value="both">Both</option>
+            </select>
+          </div>
+        </div>
+
+        <!-- Blocklist -->
+        <div style="margin-bottom:16px;">
+          <label style="font-size:12px;font-weight:600;color:#94a3b8;text-transform:uppercase;letter-spacing:0.5px;display:block;margin-bottom:6px;">Rule Blocklist <span style="font-weight:400;color:#475569;">(always flag — comma-separated rule IDs or CVEs)</span></label>
+          <input id="f-blocklist" class="dark-input" type="text" placeholder="e.g. CVE-2024-1234, python.lang.security.audit.exec">
+        </div>
+
+        <!-- Allowlist -->
+        <div style="margin-bottom:24px;">
+          <label style="font-size:12px;font-weight:600;color:#94a3b8;text-transform:uppercase;letter-spacing:0.5px;display:block;margin-bottom:6px;">Rule Allowlist <span style="font-weight:400;color:#475569;">(always ignore — overrides everything)</span></label>
+          <input id="f-allowlist" class="dark-input" type="text" placeholder="e.g. CVE-2023-9999, semgrep.rule.to.ignore">
+        </div>
+
+        <!-- Active toggle -->
+        <div style="display:flex;align-items:center;justify-content:space-between;padding:16px;background:rgba(255,255,255,0.03);border-radius:10px;margin-bottom:24px;">
+          <div>
+            <div style="font-size:14px;font-weight:600;color:#f1f5f9;">Activate policy</div>
+            <div style="font-size:12px;color:#475569;margin-top:2px;">Active policies are evaluated on every scan</div>
+          </div>
+          <label class="toggle-switch">
+            <input type="checkbox" id="f-active">
+            <span class="slider"></span>
+          </label>
+        </div>
+
+        <div id="form-error" style="display:none;padding:10px 14px;background:rgba(239,68,68,0.1);border:1px solid rgba(239,68,68,0.2);border-radius:8px;color:#f87171;font-size:13px;margin-bottom:16px;"></div>
+
+        <div style="display:flex;gap:10px;justify-content:flex-end;">
+          <button type="button" class="btn-secondary" onclick="closeModal()">Cancel</button>
+          <button type="submit" class="btn-primary" id="submit-btn">
+            <i data-lucide="save" style="width:15px;height:15px;"></i> Save Policy
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <!-- ===================== DELETE CONFIRM MODAL ===================== -->
+  <div id="delete-modal" class="modal-backdrop" style="display:none;" onclick="event.target===this&&closeDeleteModal()">
+    <div style="background:#0d1117;border:1px solid rgba(255,255,255,0.1);border-radius:16px;width:400px;padding:28px;animation:fadeInUp 0.2s ease;">
+      <div style="display:flex;align-items:center;gap:12px;margin-bottom:16px;">
+        <div style="width:40px;height:40px;background:rgba(239,68,68,0.1);border-radius:10px;display:flex;align-items:center;justify-content:center;">
+          <i data-lucide="trash-2" style="width:20px;height:20px;color:#f87171;"></i>
+        </div>
+        <div>
+          <div style="font-size:16px;font-weight:600;color:#f1f5f9;">Delete Policy</div>
+          <div style="font-size:13px;color:#475569;">This action cannot be undone</div>
+        </div>
+      </div>
+      <p style="font-size:14px;color:#94a3b8;margin-bottom:24px;">Are you sure you want to delete <strong id="delete-policy-name" style="color:#f1f5f9;"></strong>?</p>
+      <div style="display:flex;gap:10px;justify-content:flex-end;">
+        <button class="btn-secondary" onclick="closeDeleteModal()">Cancel</button>
+        <button class="btn-danger" onclick="confirmDelete()">Delete</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- ===================== EVALUATION DRAWER ===================== -->
+  <div id="eval-overlay" style="display:none;position:fixed;inset:0;background:rgba(0,0,0,0.4);z-index:290;" onclick="closeDrawer()"></div>
+  <div id="eval-drawer" class="drawer" style="display:none;">
+    <div style="padding:24px;border-bottom:1px solid rgba(255,255,255,0.08);display:flex;align-items:center;justify-content:space-between;">
+      <div>
+        <div style="font-size:16px;font-weight:700;color:#f1f5f9;" id="drawer-title">Policy Evaluation</div>
+        <div style="font-size:12px;color:#475569;margin-top:2px;" id="drawer-subtitle"></div>
+      </div>
+      <button class="btn-icon" onclick="closeDrawer()"><i data-lucide="x" style="width:18px;height:18px;color:#64748b;"></i></button>
+    </div>
+    <div id="drawer-content" style="padding:20px;"></div>
+  </div>
+
+  <script>
+    const API = '/api/v1/policies';
+    let currentPage = 1;
+    let totalPages = 1;
+    let deleteTargetId = null;
+
+    // ----------------------------------------------------------------
+    // LOAD & RENDER
+    // ----------------------------------------------------------------
+    async function loadPolicies(page = 1) {
+      currentPage = page;
+      const activeFilter = document.getElementById('filter-active').value;
+      let url = `${API}?page=${page}&page_size=20`;
+      if (activeFilter !== '') url += `&is_active=${activeFilter}`;
+
+      const res = await fetch(url);
+      const data = await res.json();
+      totalPages = data.pages || 1;
+      renderTable(data.items, data.total);
+      renderSummaryCards(data);
+    }
+
+    function renderSummaryCards(data) {
+      const active = data.items.filter(p => p.is_active).length;
+      const blocking = data.items.filter(p => p.action === 'block' || p.action === 'both').length;
+      document.getElementById('summary-cards').innerHTML = `
+        <div class="card" style="padding:20px;">
+          <div style="font-size:12px;color:#475569;font-weight:600;text-transform:uppercase;letter-spacing:0.5px;margin-bottom:10px;">Total Policies</div>
+          <div style="font-size:32px;font-weight:700;color:#f1f5f9;">${data.total}</div>
+        </div>
+        <div class="card" style="padding:20px;">
+          <div style="font-size:12px;color:#475569;font-weight:600;text-transform:uppercase;letter-spacing:0.5px;margin-bottom:10px;">Active Policies</div>
+          <div style="font-size:32px;font-weight:700;color:#10b981;">${active}</div>
+          <div style="font-size:12px;color:#475569;margin-top:4px;">of ${data.items.length} loaded</div>
+        </div>
+        <div class="card" style="padding:20px;">
+          <div style="font-size:12px;color:#475569;font-weight:600;text-transform:uppercase;letter-spacing:0.5px;margin-bottom:10px;">Blocking Policies</div>
+          <div style="font-size:32px;font-weight:700;color:#ef4444;">${blocking}</div>
+          <div style="font-size:12px;color:#475569;margin-top:4px;">block or both action</div>
+        </div>`;
+    }
+
+    function renderTable(policies, total) {
+      const tbody = document.getElementById('policy-table-body');
+      if (policies.length === 0) {
+        tbody.innerHTML = `<div style="padding:60px;text-align:center;">
+          <i data-lucide="shield-off" style="width:48px;height:48px;color:#1e293b;margin:0 auto 16px;display:block;"></i>
+          <div style="font-size:16px;font-weight:600;color:#334155;margin-bottom:8px;">No policies yet</div>
+          <div style="font-size:14px;color:#475569;">Create your first security policy to get started</div>
+        </div>`;
+        lucide.createIcons();
+        return;
+      }
+
+      tbody.innerHTML = `
+        <table style="width:100%;border-collapse:collapse;">
+          <thead>
+            <tr style="border-bottom:1px solid rgba(255,255,255,0.06);">
+              <th style="padding:12px 24px;text-align:left;font-size:11px;font-weight:600;color:#475569;text-transform:uppercase;letter-spacing:0.5px;">Policy</th>
+              <th style="padding:12px 16px;text-align:left;font-size:11px;font-weight:600;color:#475569;text-transform:uppercase;letter-spacing:0.5px;">Scan Types</th>
+              <th style="padding:12px 16px;text-align:left;font-size:11px;font-weight:600;color:#475569;text-transform:uppercase;letter-spacing:0.5px;">Min Severity</th>
+              <th style="padding:12px 16px;text-align:left;font-size:11px;font-weight:600;color:#475569;text-transform:uppercase;letter-spacing:0.5px;">Action</th>
+              <th style="padding:12px 16px;text-align:center;font-size:11px;font-weight:600;color:#475569;text-transform:uppercase;letter-spacing:0.5px;">Active</th>
+              <th style="padding:12px 24px;text-align:right;font-size:11px;font-weight:600;color:#475569;text-transform:uppercase;letter-spacing:0.5px;"></th>
+            </tr>
+          </thead>
+          <tbody>
+            ${policies.map(p => renderRow(p)).join('')}
+          </tbody>
+        </table>`;
+
+      const pag = document.getElementById('pagination');
+      pag.style.display = 'flex';
+      document.getElementById('page-info').textContent = `Page ${currentPage} of ${totalPages} — ${total} total`;
+      document.getElementById('prev-btn').disabled = currentPage <= 1;
+      document.getElementById('next-btn').disabled = currentPage >= totalPages;
+      lucide.createIcons();
+    }
+
+    function renderRow(p) {
+      const scanTypeTags = p.enabled_scan_types.length > 0
+        ? p.enabled_scan_types.map(t => `<span class="tag tag-${t}">${t}</span>`).join(' ')
+        : '<span style="font-size:12px;color:#475569;">All</span>';
+      const sevColor = {critical:'#ef4444',high:'#f97316',medium:'#eab308',low:'#22c55e',info:'#64748b'}[p.min_severity] || '#94a3b8';
+      const actionTag = `<span class="tag tag-${p.action}">${p.action}</span>`;
+      return `
+        <tr class="policy-row" style="border-bottom:1px solid rgba(255,255,255,0.04);transition:background 0.15s;">
+          <td style="padding:14px 24px;">
+            <div style="font-size:14px;font-weight:600;color:#f1f5f9;">${escHtml(p.name)}</div>
+            ${p.description ? `<div style="font-size:12px;color:#475569;margin-top:2px;">${escHtml(p.description)}</div>` : ''}
+            ${p.rule_blocklist.length > 0 ? `<div style="margin-top:4px;font-size:11px;color:#f87171;">🚫 ${p.rule_blocklist.length} blocklisted</div>` : ''}
+            ${p.rule_allowlist.length > 0 ? `<div style="margin-top:2px;font-size:11px;color:#10b981;">✓ ${p.rule_allowlist.length} allowed</div>` : ''}
+          </td>
+          <td style="padding:14px 16px;"><div style="display:flex;gap:4px;flex-wrap:wrap;">${scanTypeTags}</div></td>
+          <td style="padding:14px 16px;"><span style="font-size:13px;font-weight:600;color:${sevColor};text-transform:capitalize;">${p.min_severity}+</span></td>
+          <td style="padding:14px 16px;">${actionTag}</td>
+          <td style="padding:14px 16px;text-align:center;">
+            <label class="toggle-switch" title="${p.is_active ? 'Deactivate' : 'Activate'}">
+              <input type="checkbox" ${p.is_active ? 'checked' : ''} onchange="toggleActive('${p.id}', this.checked)">
+              <span class="slider"></span>
+            </label>
+          </td>
+          <td style="padding:14px 24px;text-align:right;">
+            <div style="display:flex;gap:6px;justify-content:flex-end;align-items:center;">
+              <button class="btn-icon" title="Evaluate" onclick="evaluatePolicy('${p.id}', '${escHtml(p.name)}')">
+                <i data-lucide="play" style="width:15px;height:15px;color:#00d4ff;"></i>
+              </button>
+              <button class="btn-icon" title="Edit" onclick="openEditModal(${JSON.stringify(p).replace(/"/g, '&quot;')})">
+                <i data-lucide="pencil" style="width:15px;height:15px;color:#94a3b8;"></i>
+              </button>
+              <button class="btn-icon" title="Delete" onclick="openDeleteModal('${p.id}', '${escHtml(p.name)}')">
+                <i data-lucide="trash-2" style="width:15px;height:15px;color:#f87171;"></i>
+              </button>
+            </div>
+          </td>
+        </tr>`;
+    }
+
+    function escHtml(s) {
+      return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+    }
+
+    function changePage(delta) {
+      const next = currentPage + delta;
+      if (next >= 1 && next <= totalPages) loadPolicies(next);
+    }
+
+    // ----------------------------------------------------------------
+    // ACTIVE TOGGLE
+    // ----------------------------------------------------------------
+    async function toggleActive(id, active) {
+      await fetch(`${API}/${id}`, {
+        method: 'PATCH',
+        headers: {'Content-Type':'application/json'},
+        body: JSON.stringify({is_active: active}),
+      });
+    }
+
+    // ----------------------------------------------------------------
+    // CREATE / EDIT MODAL
+    // ----------------------------------------------------------------
+    function openModal() {
+      document.getElementById('modal-title').textContent = 'New Policy';
+      document.getElementById('edit-id').value = '';
+      document.getElementById('policy-form').reset();
+      document.querySelectorAll('#scan-type-chips .chip').forEach(c => c.classList.remove('active'));
+      document.getElementById('form-error').style.display = 'none';
+      document.getElementById('modal').style.display = 'flex';
+      lucide.createIcons();
+    }
+
+    function openEditModal(p) {
+      document.getElementById('modal-title').textContent = 'Edit Policy';
+      document.getElementById('edit-id').value = p.id;
+      document.getElementById('f-name').value = p.name;
+      document.getElementById('f-desc').value = p.description || '';
+      document.getElementById('f-severity').value = p.min_severity;
+      document.getElementById('f-action').value = p.action;
+      document.getElementById('f-active').checked = p.is_active;
+      document.getElementById('f-blocklist').value = (p.rule_blocklist || []).join(', ');
+      document.getElementById('f-allowlist').value = (p.rule_allowlist || []).join(', ');
+      document.querySelectorAll('#scan-type-chips .chip').forEach(c => {
+        c.classList.toggle('active', (p.enabled_scan_types || []).includes(c.dataset.type));
+      });
+      document.getElementById('form-error').style.display = 'none';
+      document.getElementById('modal').style.display = 'flex';
+      lucide.createIcons();
+    }
+
+    function closeModal() { document.getElementById('modal').style.display = 'none'; }
+    function closeModalOnBackdrop(e) { if (e.target === document.getElementById('modal')) closeModal(); }
+
+    function toggleChip(el) { el.classList.toggle('active'); }
+
+    function parseList(str) {
+      return str.split(',').map(s => s.trim()).filter(Boolean);
+    }
+
+    async function submitPolicy(e) {
+      e.preventDefault();
+      const id = document.getElementById('edit-id').value;
+      const errEl = document.getElementById('form-error');
+      errEl.style.display = 'none';
+
+      const selectedTypes = [...document.querySelectorAll('#scan-type-chips .chip.active')].map(c => c.dataset.type);
+      const payload = {
+        name: document.getElementById('f-name').value.trim(),
+        description: document.getElementById('f-desc').value.trim() || null,
+        min_severity: document.getElementById('f-severity').value,
+        action: document.getElementById('f-action').value,
+        is_active: document.getElementById('f-active').checked,
+        enabled_scan_types: selectedTypes,
+        rule_blocklist: parseList(document.getElementById('f-blocklist').value),
+        rule_allowlist: parseList(document.getElementById('f-allowlist').value),
+      };
+
+      const url = id ? `${API}/${id}` : API;
+      const method = id ? 'PATCH' : 'POST';
+      const res = await fetch(url, { method, headers: {'Content-Type':'application/json'}, body: JSON.stringify(payload) });
+      const data = await res.json();
+
+      if (!res.ok) {
+        let msg = data.detail || 'An error occurred';
+        if (Array.isArray(msg)) msg = msg.map(e => e.msg).join('; ');
+        errEl.textContent = msg;
+        errEl.style.display = 'block';
+        return;
+      }
+      closeModal();
+      loadPolicies(currentPage);
+    }
+
+    // ----------------------------------------------------------------
+    // DELETE
+    // ----------------------------------------------------------------
+    function openDeleteModal(id, name) {
+      deleteTargetId = id;
+      document.getElementById('delete-policy-name').textContent = name;
+      document.getElementById('delete-modal').style.display = 'flex';
+    }
+    function closeDeleteModal() {
+      document.getElementById('delete-modal').style.display = 'none';
+      deleteTargetId = null;
+    }
+    async function confirmDelete() {
+      if (!deleteTargetId) return;
+      await fetch(`${API}/${deleteTargetId}`, { method: 'DELETE' });
+      closeDeleteModal();
+      loadPolicies(currentPage);
+    }
+
+    // ----------------------------------------------------------------
+    // EVALUATION DRAWER
+    // ----------------------------------------------------------------
+    async function evaluatePolicy(id, name) {
+      showDrawer(`Evaluating: ${name}`, 'Running policy against open findings…');
+      const res = await fetch(`${API}/${id}/evaluate`);
+      const data = await res.json();
+      renderEvalResult([data], name);
+    }
+
+    async function seedDefaultPolicies() {
+      const btn = document.getElementById('seed-btn');
+      btn.disabled = true;
+      btn.innerHTML = '<i data-lucide="loader" style="width:14px;height:14px;display:inline-block;vertical-align:middle;margin-right:4px;"></i> Seeding…';
+      lucide.createIcons();
+      try {
+        const res = await fetch(`${API}/seed`, { method: 'POST' });
+        const data = await res.json();
+        if (data.policies_created > 0) {
+          showToast(`Created ${data.policies_created} default policies`, 'success');
+          loadPolicies();
+        } else {
+          showToast('Policies already exist — seed skipped', 'info');
+        }
+      } catch (e) {
+        showToast('Failed to seed policies', 'error');
+      } finally {
+        btn.disabled = false;
+        btn.innerHTML = '<i data-lucide="database" style="width:14px;height:14px;display:inline-block;vertical-align:middle;margin-right:4px;"></i> Seed Defaults';
+        lucide.createIcons();
+      }
+    }
+
+    async function evaluateAll() {
+      showDrawer('All Active Policies', 'Evaluating against all open findings…');
+      const res = await fetch(`${API}/evaluate/all`);
+      const data = await res.json();
+      if (data.length === 0) {
+        document.getElementById('drawer-content').innerHTML = `<div style="padding:40px;text-align:center;color:#475569;">No active policies to evaluate.</div>`;
+        return;
+      }
+      renderEvalResult(data, null);
+    }
+
+    function showDrawer(title, subtitle) {
+      document.getElementById('drawer-title').textContent = title;
+      document.getElementById('drawer-subtitle').textContent = subtitle;
+      document.getElementById('drawer-content').innerHTML = `<div style="padding:40px;text-align:center;color:#475569;animation:pulse 1s infinite;">Running evaluation…</div>`;
+      document.getElementById('eval-overlay').style.display = 'block';
+      document.getElementById('eval-drawer').style.display = 'block';
+      lucide.createIcons();
+    }
+
+    function closeDrawer() {
+      document.getElementById('eval-overlay').style.display = 'none';
+      document.getElementById('eval-drawer').style.display = 'none';
+    }
+
+    function renderEvalResult(results, singleName) {
+      const title = singleName || 'All Active Policies';
+      const totalViolations = results.reduce((s, r) => s + r.total_violations, 0);
+      const anyBlocked = results.some(r => r.blocked);
+
+      document.getElementById('drawer-subtitle').textContent =
+        `${results.length} polic${results.length === 1 ? 'y' : 'ies'} evaluated · ${totalViolations} violation${totalViolations !== 1 ? 's' : ''}`;
+
+      let html = '';
+
+      if (totalViolations === 0) {
+        html = `<div style="text-align:center;padding:40px 20px;">
+          <i data-lucide="shield-check" style="width:48px;height:48px;color:#10b981;display:block;margin:0 auto 12px;"></i>
+          <div style="font-size:16px;font-weight:600;color:#10b981;margin-bottom:8px;">No violations found</div>
+          <div style="font-size:13px;color:#475569;">All findings are within policy thresholds</div>
+        </div>`;
+      } else {
+        if (anyBlocked) {
+          html += `<div style="padding:12px 16px;background:rgba(239,68,68,0.1);border:1px solid rgba(239,68,68,0.2);border-radius:10px;margin-bottom:16px;display:flex;align-items:center;gap:10px;">
+            <i data-lucide="shield-x" style="width:18px;height:18px;color:#f87171;flex-shrink:0;"></i>
+            <span style="font-size:14px;color:#f87171;font-weight:600;">Policy violation — scan would be blocked</span>
+          </div>`;
+        }
+
+        for (const r of results) {
+          if (results.length > 1) {
+            html += `<div style="font-size:13px;font-weight:600;color:#94a3b8;text-transform:uppercase;letter-spacing:0.5px;margin-bottom:10px;margin-top:16px;">${escHtml(r.policy_name)}</div>`;
+          }
+          if (r.violations.length === 0) {
+            html += `<div style="padding:10px 14px;background:rgba(16,185,129,0.05);border-radius:8px;font-size:13px;color:#6ee7b7;margin-bottom:8px;">✓ No violations</div>`;
+            continue;
+          }
+          for (const v of r.violations) {
+            const sevColor = {critical:'#ef4444',high:'#f97316',medium:'#eab308',low:'#22c55e',info:'#64748b'}[v.severity] || '#94a3b8';
+            const reasonLabel = v.reason === 'blocklisted_rule' ? '🚫 Blocklisted' : '⚠ Severity';
+            html += `<div style="padding:12px;background:rgba(255,255,255,0.03);border:1px solid rgba(255,255,255,0.07);border-radius:10px;margin-bottom:8px;">
+              <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:6px;">
+                <span style="font-size:13px;font-weight:600;color:#f1f5f9;">${escHtml(v.finding_title)}</span>
+                <span style="font-size:11px;font-weight:600;color:${sevColor};text-transform:uppercase;">${v.severity}</span>
+              </div>
+              <div style="display:flex;gap:8px;flex-wrap:wrap;align-items:center;">
+                <span style="font-size:11px;color:#475569;">${escHtml(v.scanner)} / ${escHtml(v.finding_type)}</span>
+                <span style="font-size:11px;color:#64748b;">${reasonLabel}</span>
+                ${v.rule_id ? `<span style="font-size:11px;color:#475569;font-family:monospace;">${escHtml(v.rule_id)}</span>` : ''}
+                ${v.cve_id ? `<span style="font-size:11px;color:#f97316;">${escHtml(v.cve_id)}</span>` : ''}
+              </div>
+            </div>`;
+          }
+        }
+      }
+
+      document.getElementById('drawer-content').innerHTML = html;
+      lucide.createIcons();
+    }
+
+    // ----------------------------------------------------------------
+    // TOAST
+    // ----------------------------------------------------------------
+    function showToast(message, type='success') {
+      const colors = {success:'#10b981', error:'#ef4444', warning:'#f59e0b', info:'#00d4ff'};
+      const icons = {success:'check-circle', error:'alert-circle', warning:'alert-triangle', info:'info'};
+      const toast = document.createElement('div');
+      toast.style.cssText = `position:fixed;bottom:24px;right:24px;z-index:9999;background:rgba(13,17,23,0.95);border:1px solid ${colors[type]}44;border-left:3px solid ${colors[type]};padding:14px 18px;border-radius:10px;display:flex;align-items:center;gap:10px;color:#f1f5f9;font-size:14px;font-weight:500;backdrop-filter:blur(20px);box-shadow:0 8px 32px rgba(0,0,0,0.5);`;
+      const _icon = document.createElement('i');
+      _icon.setAttribute('data-lucide', icons[type]);
+      _icon.style.cssText = `width:18px;height:18px;color:${colors[type]};flex-shrink:0;`;
+      const _msg = document.createElement('span');
+      _msg.textContent = message;
+      toast.appendChild(_icon);
+      toast.appendChild(_msg);
+      document.body.appendChild(toast);
+      lucide.createIcons();
+      setTimeout(() => toast.remove(), 3500);
+    }
+
+    // ----------------------------------------------------------------
+    // INIT
+    // ----------------------------------------------------------------
+    lucide.createIcons();
+    loadPolicies();
+  </script>
+</body>
+</html>

--- a/frontend/policies.html
+++ b/frontend/policies.html
@@ -523,7 +523,7 @@
     // ----------------------------------------------------------------
     async function evaluatePolicy(id, name) {
       showDrawer(`Evaluating: ${name}`, 'Running policy against open findings…');
-      const res = await fetch(`${API}/${id}/evaluate`);
+      const res = await fetch(`${API}/${id}/evaluate`, { method: 'POST' });
       const data = await res.json();
       renderEvalResult([data], name);
     }

--- a/frontend/reports.html
+++ b/frontend/reports.html
@@ -59,6 +59,12 @@
       <a href="/reports.html" class="nav-link" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;background:linear-gradient(135deg,rgba(0,212,255,0.15),rgba(99,102,241,0.15));color:#00d4ff;border:1px solid rgba(0,212,255,0.2);">
         <i data-lucide="bar-chart-3" style="width:18px;height:18px;"></i> Reports
       </a>
+      <a href="/policies.html" class="nav-link" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;color:#94a3b8;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;">
+        <i data-lucide="shield-check" style="width:18px;height:18px;"></i> Policies
+      </a>
+      <a href="/secrets.html" class="nav-link" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;color:#94a3b8;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;">
+        <i data-lucide="key" style="width:18px;height:18px;"></i> Secrets
+      </a>
       <div style="font-size:10px;color:#475569;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;padding:16px 8px 4px;">Developer</div>
       <a href="/docs" class="nav-link" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;color:#94a3b8;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;">
         <i data-lucide="code-2" style="width:18px;height:18px;"></i> API Docs

--- a/frontend/repositories.html
+++ b/frontend/repositories.html
@@ -54,6 +54,12 @@
       <a href="/reports.html" class="nav-link" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;color:#94a3b8;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;">
         <i data-lucide="bar-chart-3" style="width:18px;height:18px;"></i> Reports
       </a>
+      <a href="/policies.html" class="nav-link" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;color:#94a3b8;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;">
+        <i data-lucide="shield-check" style="width:18px;height:18px;"></i> Policies
+      </a>
+      <a href="/secrets.html" class="nav-link" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;color:#94a3b8;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;">
+        <i data-lucide="key" style="width:18px;height:18px;"></i> Secrets
+      </a>
       <div style="font-size:10px;color:#475569;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;padding:16px 8px 4px;">Developer</div>
       <a href="/docs" class="nav-link" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;color:#94a3b8;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;">
         <i data-lucide="code-2" style="width:18px;height:18px;"></i> API Docs

--- a/frontend/secrets.html
+++ b/frontend/secrets.html
@@ -1,0 +1,648 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Snitch — Secrets Scanner</title>
+  <script src="/static/js/lucide.min.js"></script>
+  <style>
+    * { box-sizing: border-box; }
+    body { font-family: "Inter", system-ui, -apple-system, sans-serif; background: #0a0e1a; color: #f1f5f9; margin: 0; padding: 0; min-height: 100vh; }
+    @keyframes pulse { 0%,100%{opacity:1} 50%{opacity:0.5} }
+    @keyframes fadeInUp { from{transform:translateY(20px);opacity:0} to{transform:translateY(0);opacity:1} }
+    @keyframes spin { to{transform:rotate(360deg)} }
+    .nav-link:hover { background:rgba(255,255,255,0.05) !important; color:#e2e8f0 !important; }
+    .btn-primary { background:linear-gradient(135deg,#00d4ff,#6366f1);color:white;border:none;padding:10px 20px;border-radius:10px;font-weight:600;font-size:14px;cursor:pointer;transition:all 0.2s;display:inline-flex;align-items:center;gap:8px; }
+    .btn-primary:hover { transform:translateY(-1px);box-shadow:0 4px 20px rgba(0,212,255,0.4); }
+    .btn-secondary { background:rgba(255,255,255,0.05);color:#94a3b8;border:1px solid rgba(255,255,255,0.1);padding:8px 16px;border-radius:8px;font-weight:500;font-size:13px;cursor:pointer;transition:all 0.2s;display:inline-flex;align-items:center;gap:6px; }
+    .btn-secondary:hover { background:rgba(255,255,255,0.1);color:#f1f5f9; }
+    .btn-danger { background:rgba(239,68,68,0.15);color:#f87171;border:1px solid rgba(239,68,68,0.3);padding:6px 12px;border-radius:6px;font-size:12px;font-weight:500;cursor:pointer;transition:all 0.2s;display:inline-flex;align-items:center;gap:4px; }
+    .btn-danger:hover { background:rgba(239,68,68,0.25); }
+    .card { background:rgba(13,17,23,0.8);border:1px solid rgba(255,255,255,0.08);border-radius:16px;backdrop-filter:blur(20px); }
+    .table-row:hover { background:rgba(255,255,255,0.03) !important; }
+    select, input[type="text"], input[type="email"], textarea { background:rgba(255,255,255,0.05);border:1px solid rgba(255,255,255,0.1);color:#f1f5f9;border-radius:8px;padding:8px 12px;font-size:13px;font-family:inherit;width:100%; }
+    select:focus, input:focus, textarea:focus { outline:none;border-color:rgba(0,212,255,0.4); }
+    select option { background:#1e2533; }
+    .tab { padding:8px 16px;border-radius:8px;cursor:pointer;font-size:13px;font-weight:500;color:#94a3b8;transition:all 0.2s;border:none;background:none; }
+    .tab.active { background:linear-gradient(135deg,rgba(0,212,255,0.15),rgba(99,102,241,0.15));color:#00d4ff;border:1px solid rgba(0,212,255,0.2); }
+    .badge { display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:12px;font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:0.5px; }
+    .badge-critical { background:rgba(239,68,68,0.15);color:#f87171; }
+    .badge-high { background:rgba(249,115,22,0.15);color:#fb923c; }
+    .badge-medium { background:rgba(234,179,8,0.15);color:#facc15; }
+    .badge-low { background:rgba(59,130,246,0.15);color:#60a5fa; }
+    .badge-open { background:rgba(16,185,129,0.1);color:#34d399; }
+    .badge-accepted { background:rgba(100,116,139,0.15);color:#94a3b8; }
+    .badge-false_positive { background:rgba(99,102,241,0.15);color:#a5b4fc; }
+    .spinner { width:16px;height:16px;border:2px solid rgba(255,255,255,0.1);border-top-color:#00d4ff;border-radius:50%;animation:spin 0.7s linear infinite; }
+    ::-webkit-scrollbar { width:6px; }
+    ::-webkit-scrollbar-track { background:rgba(255,255,255,0.02); }
+    ::-webkit-scrollbar-thumb { background:rgba(255,255,255,0.1);border-radius:3px; }
+    .modal-overlay { position:fixed;inset:0;background:rgba(0,0,0,0.7);backdrop-filter:blur(4px);z-index:200;display:flex;align-items:center;justify-content:center; }
+    .modal { background:#0d1117;border:1px solid rgba(255,255,255,0.1);border-radius:16px;padding:28px;width:520px;max-width:95vw; }
+  </style>
+</head>
+<body>
+
+  <!-- Sidebar -->
+  <aside style="width:260px;min-height:100vh;background:#080c18;border-right:1px solid rgba(255,255,255,0.08);display:flex;flex-direction:column;position:fixed;left:0;top:0;z-index:100;">
+    <div style="padding:24px 20px;border-bottom:1px solid rgba(255,255,255,0.08);display:flex;align-items:center;gap:12px;">
+      <div style="width:40px;height:40px;background:linear-gradient(135deg,#00d4ff22,#6366f122);border:1px solid #00d4ff44;border-radius:12px;display:flex;align-items:center;justify-content:center;">
+        <i data-lucide="shield-alert" style="width:20px;height:20px;color:#00d4ff;"></i>
+      </div>
+      <div>
+        <div style="font-size:20px;font-weight:800;color:#f1f5f9;letter-spacing:-0.5px;">Snitch</div>
+        <div style="font-size:11px;color:#00d4ff;font-weight:500;letter-spacing:1px;text-transform:uppercase;">AppSec Platform</div>
+      </div>
+    </div>
+    <nav style="flex:1;padding:16px 12px;">
+      <div style="font-size:10px;color:#475569;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;padding:8px 8px 4px;">Main Menu</div>
+      <a href="/" class="nav-link" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;color:#94a3b8;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;">
+        <i data-lucide="layout-dashboard" style="width:18px;height:18px;"></i> Dashboard
+      </a>
+      <a href="/applications.html" class="nav-link" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;color:#94a3b8;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;">
+        <i data-lucide="layers" style="width:18px;height:18px;"></i> Applications
+      </a>
+      <a href="/repositories.html" class="nav-link" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;color:#94a3b8;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;">
+        <i data-lucide="git-branch" style="width:18px;height:18px;"></i> Repositories
+      </a>
+      <a href="/reports.html" class="nav-link" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;color:#94a3b8;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;">
+        <i data-lucide="bar-chart-3" style="width:18px;height:18px;"></i> Reports
+      </a>
+      <a href="/policies.html" class="nav-link" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;color:#94a3b8;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;">
+        <i data-lucide="shield-check" style="width:18px;height:18px;"></i> Policies
+      </a>
+      <a href="/secrets.html" class="nav-link" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;color:#00d4ff;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;background:linear-gradient(135deg,rgba(0,212,255,0.15),rgba(99,102,241,0.15));border:1px solid rgba(0,212,255,0.2);">
+        <i data-lucide="key" style="width:18px;height:18px;"></i> Secrets
+      </a>
+      <div style="font-size:10px;color:#475569;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;padding:16px 8px 4px;">Developer</div>
+      <a href="/docs" class="nav-link" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;color:#94a3b8;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;">
+        <i data-lucide="code-2" style="width:18px;height:18px;"></i> API Docs
+        <i data-lucide="external-link" style="width:12px;height:12px;margin-left:auto;"></i>
+      </a>
+    </nav>
+    <div style="padding:16px 20px;border-top:1px solid rgba(255,255,255,0.08);">
+      <div style="display:flex;align-items:center;gap:8px;">
+        <div style="width:8px;height:8px;background:#10b981;border-radius:50%;box-shadow:0 0 8px #10b981;"></div>
+        <span style="font-size:12px;color:#475569;">All systems operational</span>
+      </div>
+    </div>
+  </aside>
+
+  <!-- Main -->
+  <div style="margin-left:260px;min-height:100vh;">
+    <header style="background:rgba(8,12,24,0.9);backdrop-filter:blur(20px);border-bottom:1px solid rgba(255,255,255,0.08);padding:16px 32px;display:flex;align-items:center;justify-content:space-between;position:sticky;top:0;z-index:50;">
+      <div>
+        <h1 style="font-size:22px;font-weight:700;color:#f1f5f9;margin:0;">Secrets Scanner</h1>
+        <p style="font-size:13px;color:#475569;margin:2px 0 0;">Credential and secret detection via Gitleaks</p>
+      </div>
+    </header>
+
+    <main style="padding:32px;">
+
+      <!-- Stats Row -->
+      <div style="display:grid;grid-template-columns:repeat(4,1fr);gap:20px;margin-bottom:28px;" id="stats-row">
+        <div class="card" style="padding:20px;animation:pulse 1.5s infinite;" id="stat-total">
+          <div style="font-size:12px;color:#475569;font-weight:600;text-transform:uppercase;letter-spacing:1px;margin-bottom:8px;">Total Secrets</div>
+          <div style="font-size:32px;font-weight:700;color:#f1f5f9;">—</div>
+        </div>
+        <div class="card" style="padding:20px;animation:pulse 1.5s infinite;" id="stat-open">
+          <div style="font-size:12px;color:#475569;font-weight:600;text-transform:uppercase;letter-spacing:1px;margin-bottom:8px;">Open</div>
+          <div style="font-size:32px;font-weight:700;color:#f87171;">—</div>
+        </div>
+        <div class="card" style="padding:20px;animation:pulse 1.5s infinite;" id="stat-high">
+          <div style="font-size:12px;color:#475569;font-weight:600;text-transform:uppercase;letter-spacing:1px;margin-bottom:8px;">High Severity</div>
+          <div style="font-size:32px;font-weight:700;color:#fb923c;">—</div>
+        </div>
+        <div class="card" style="padding:20px;animation:pulse 1.5s infinite;" id="stat-patterns">
+          <div style="font-size:12px;color:#475569;font-weight:600;text-transform:uppercase;letter-spacing:1px;margin-bottom:8px;">Custom Patterns</div>
+          <div style="font-size:32px;font-weight:700;color:#00d4ff;">—</div>
+        </div>
+      </div>
+
+      <!-- Tabs -->
+      <div style="display:flex;gap:8px;margin-bottom:24px;">
+        <button class="tab active" id="tab-findings" onclick="switchTab('findings')">
+          <i data-lucide="search" style="width:14px;height:14px;display:inline;vertical-align:middle;margin-right:4px;"></i>Findings
+        </button>
+        <button class="tab" id="tab-patterns" onclick="switchTab('patterns')">
+          <i data-lucide="regex" style="width:14px;height:14px;display:inline;vertical-align:middle;margin-right:4px;"></i>Custom Patterns
+        </button>
+      </div>
+
+      <!-- Findings Panel -->
+      <div id="panel-findings">
+        <div class="card" style="padding:20px;">
+          <!-- Filters -->
+          <div style="display:flex;gap:12px;margin-bottom:20px;flex-wrap:wrap;align-items:flex-end;">
+            <div style="flex:1;min-width:180px;">
+              <label style="font-size:11px;color:#475569;font-weight:600;display:block;margin-bottom:4px;">APPLICATION</label>
+              <select id="filter-app" onchange="loadFindings()">
+                <option value="">All Applications</option>
+              </select>
+            </div>
+            <div style="width:160px;">
+              <label style="font-size:11px;color:#475569;font-weight:600;display:block;margin-bottom:4px;">SEVERITY</label>
+              <select id="filter-severity" onchange="loadFindings()">
+                <option value="">All Severities</option>
+                <option value="critical">Critical</option>
+                <option value="high">High</option>
+                <option value="medium">Medium</option>
+                <option value="low">Low</option>
+              </select>
+            </div>
+            <div style="width:160px;">
+              <label style="font-size:11px;color:#475569;font-weight:600;display:block;margin-bottom:4px;">STATUS</label>
+              <select id="filter-status" onchange="loadFindings()">
+                <option value="">All Statuses</option>
+                <option value="open">Open</option>
+                <option value="accepted">Accepted</option>
+                <option value="false_positive">False Positive</option>
+              </select>
+            </div>
+          </div>
+
+          <!-- Table -->
+          <div style="overflow-x:auto;">
+            <table style="width:100%;border-collapse:collapse;">
+              <thead>
+                <tr style="border-bottom:1px solid rgba(255,255,255,0.06);">
+                  <th style="text-align:left;padding:10px 12px;font-size:11px;color:#475569;font-weight:600;text-transform:uppercase;letter-spacing:1px;">Rule / Secret Type</th>
+                  <th style="text-align:left;padding:10px 12px;font-size:11px;color:#475569;font-weight:600;text-transform:uppercase;letter-spacing:1px;">Application</th>
+                  <th style="text-align:left;padding:10px 12px;font-size:11px;color:#475569;font-weight:600;text-transform:uppercase;letter-spacing:1px;">File</th>
+                  <th style="text-align:left;padding:10px 12px;font-size:11px;color:#475569;font-weight:600;text-transform:uppercase;letter-spacing:1px;">Severity</th>
+                  <th style="text-align:left;padding:10px 12px;font-size:11px;color:#475569;font-weight:600;text-transform:uppercase;letter-spacing:1px;">Status</th>
+                  <th style="text-align:left;padding:10px 12px;font-size:11px;color:#475569;font-weight:600;text-transform:uppercase;letter-spacing:1px;">First Seen</th>
+                  <th style="text-align:right;padding:10px 12px;font-size:11px;color:#475569;font-weight:600;text-transform:uppercase;letter-spacing:1px;">Actions</th>
+                </tr>
+              </thead>
+              <tbody id="findings-tbody">
+                <tr><td colspan="7" style="text-align:center;padding:40px;color:#475569;">Loading...</td></tr>
+              </tbody>
+            </table>
+          </div>
+
+          <!-- Pagination -->
+          <div style="display:flex;align-items:center;justify-content:space-between;margin-top:16px;" id="findings-pagination">
+            <div style="font-size:13px;color:#475569;" id="findings-count"></div>
+            <div style="display:flex;gap:8px;" id="findings-pages"></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Custom Patterns Panel -->
+      <div id="panel-patterns" style="display:none;">
+        <div style="display:flex;justify-content:flex-end;margin-bottom:16px;">
+          <button class="btn-primary" onclick="openPatternModal()">
+            <i data-lucide="plus" style="width:16px;height:16px;"></i> Add Pattern
+          </button>
+        </div>
+
+        <div class="card" style="padding:20px;">
+          <div style="overflow-x:auto;">
+            <table style="width:100%;border-collapse:collapse;">
+              <thead>
+                <tr style="border-bottom:1px solid rgba(255,255,255,0.06);">
+                  <th style="text-align:left;padding:10px 12px;font-size:11px;color:#475569;font-weight:600;text-transform:uppercase;letter-spacing:1px;">Name</th>
+                  <th style="text-align:left;padding:10px 12px;font-size:11px;color:#475569;font-weight:600;text-transform:uppercase;letter-spacing:1px;">Regex Pattern</th>
+                  <th style="text-align:left;padding:10px 12px;font-size:11px;color:#475569;font-weight:600;text-transform:uppercase;letter-spacing:1px;">Severity</th>
+                  <th style="text-align:left;padding:10px 12px;font-size:11px;color:#475569;font-weight:600;text-transform:uppercase;letter-spacing:1px;">Active</th>
+                  <th style="text-align:right;padding:10px 12px;font-size:11px;color:#475569;font-weight:600;text-transform:uppercase;letter-spacing:1px;">Actions</th>
+                </tr>
+              </thead>
+              <tbody id="patterns-tbody">
+                <tr><td colspan="5" style="text-align:center;padding:40px;color:#475569;">Loading...</td></tr>
+              </tbody>
+            </table>
+          </div>
+
+          <!-- Test Pattern inline -->
+          <div style="margin-top:24px;padding-top:20px;border-top:1px solid rgba(255,255,255,0.06);">
+            <div style="font-size:14px;font-weight:600;color:#f1f5f9;margin-bottom:12px;">Test a Pattern</div>
+            <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-bottom:12px;">
+              <div>
+                <label style="font-size:11px;color:#475569;font-weight:600;display:block;margin-bottom:4px;">REGEX PATTERN</label>
+                <input type="text" id="test-pattern-input" placeholder="e.g. AKIA[0-9A-Z]{16}" oninput="clearTestResult()">
+              </div>
+              <div>
+                <label style="font-size:11px;color:#475569;font-weight:600;display:block;margin-bottom:4px;">SAMPLE TEXT</label>
+                <input type="text" id="test-sample-input" placeholder="Paste text to test against">
+              </div>
+            </div>
+            <button class="btn-secondary" onclick="runPatternTest()">
+              <i data-lucide="play" style="width:14px;height:14px;"></i> Test Pattern
+            </button>
+            <div id="test-result" style="margin-top:12px;display:none;"></div>
+          </div>
+        </div>
+      </div>
+
+    </main>
+  </div>
+
+  <!-- Pattern Modal -->
+  <div class="modal-overlay" id="pattern-modal" style="display:none;" onclick="closePatternModalIfBackground(event)">
+    <div class="modal">
+      <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:20px;">
+        <div style="font-size:16px;font-weight:600;color:#f1f5f9;" id="modal-title">Add Custom Pattern</div>
+        <button onclick="closePatternModal()" style="background:none;border:none;color:#475569;cursor:pointer;padding:4px;">
+          <i data-lucide="x" style="width:18px;height:18px;"></i>
+        </button>
+      </div>
+      <input type="hidden" id="modal-pattern-id">
+      <div style="display:flex;flex-direction:column;gap:14px;">
+        <div>
+          <label style="font-size:11px;color:#475569;font-weight:600;display:block;margin-bottom:4px;">NAME *</label>
+          <input type="text" id="modal-name" placeholder="e.g. AWS Access Key">
+        </div>
+        <div>
+          <label style="font-size:11px;color:#475569;font-weight:600;display:block;margin-bottom:4px;">REGEX PATTERN *</label>
+          <input type="text" id="modal-pattern" placeholder="e.g. AKIA[0-9A-Z]{16}" oninput="validateModalPattern()">
+          <div id="modal-pattern-error" style="font-size:11px;color:#f87171;margin-top:4px;display:none;"></div>
+        </div>
+        <div>
+          <label style="font-size:11px;color:#475569;font-weight:600;display:block;margin-bottom:4px;">DESCRIPTION</label>
+          <input type="text" id="modal-description" placeholder="What does this pattern detect?">
+        </div>
+        <div>
+          <label style="font-size:11px;color:#475569;font-weight:600;display:block;margin-bottom:4px;">SEVERITY</label>
+          <select id="modal-severity">
+            <option value="critical">Critical</option>
+            <option value="high" selected>High</option>
+            <option value="medium">Medium</option>
+            <option value="low">Low</option>
+          </select>
+        </div>
+        <div style="display:flex;align-items:center;gap:8px;">
+          <input type="checkbox" id="modal-active" checked style="width:auto;">
+          <label for="modal-active" style="font-size:13px;color:#94a3b8;cursor:pointer;">Active (included in scans)</label>
+        </div>
+      </div>
+      <div style="display:flex;justify-content:flex-end;gap:10px;margin-top:24px;">
+        <button class="btn-secondary" onclick="closePatternModal()">Cancel</button>
+        <button class="btn-primary" onclick="savePattern()" id="modal-save-btn">
+          <i data-lucide="save" style="width:14px;height:14px;"></i> Save Pattern
+        </button>
+      </div>
+    </div>
+  </div>
+
+<script>
+const API = '/api/v1';
+let currentFindingsPage = 1;
+let appsMap = {};
+
+// -----------------------------------------------------------------------
+// Init
+// -----------------------------------------------------------------------
+async function init() {
+  await Promise.all([loadApps(), loadStats(), loadFindings(), loadPatternCount()]);
+  lucide.createIcons();
+}
+
+async function loadApps() {
+  try {
+    const r = await fetch(`${API}/applications?page=1&page_size=200`);
+    const d = await r.json();
+    appsMap = {};
+    const sel = document.getElementById('filter-app');
+    (d.items || []).forEach(a => {
+      appsMap[a.id] = a.name;
+      const opt = document.createElement('option');
+      opt.value = a.id;
+      opt.textContent = a.name;
+      sel.appendChild(opt);
+    });
+  } catch(e) { console.error(e); }
+}
+
+async function loadStats() {
+  try {
+    const r = await fetch(`${API}/secrets/findings/stats`);
+    const d = await r.json();
+    setStatCard('stat-total', d.total ?? 0, '#f1f5f9');
+    setStatCard('stat-open', d.open ?? 0, '#f87171');
+    setStatCard('stat-high', d.high ?? 0, '#fb923c');
+  } catch(e) { console.error(e); }
+}
+
+function setStatCard(id, value, color) {
+  const el = document.getElementById(id);
+  el.style.removeProperty('animation');
+  el.querySelector('div:last-child').textContent = value;
+  el.querySelector('div:last-child').style.color = color;
+}
+
+async function loadPatternCount() {
+  try {
+    const r = await fetch(`${API}/secrets/patterns?page_size=1`);
+    const d = await r.json();
+    setStatCard('stat-patterns', d.total ?? 0, '#00d4ff');
+  } catch(e) {}
+}
+
+// -----------------------------------------------------------------------
+// Tabs
+// -----------------------------------------------------------------------
+function switchTab(tab) {
+  document.getElementById('panel-findings').style.display = tab === 'findings' ? '' : 'none';
+  document.getElementById('panel-patterns').style.display = tab === 'patterns' ? '' : 'none';
+  document.getElementById('tab-findings').className = 'tab' + (tab === 'findings' ? ' active' : '');
+  document.getElementById('tab-patterns').className = 'tab' + (tab === 'patterns' ? ' active' : '');
+  if (tab === 'patterns') loadPatterns();
+  lucide.createIcons();
+}
+
+// -----------------------------------------------------------------------
+// Findings
+// -----------------------------------------------------------------------
+async function loadFindings(page = 1) {
+  currentFindingsPage = page;
+  const app = document.getElementById('filter-app').value;
+  const sev = document.getElementById('filter-severity').value;
+  const sta = document.getElementById('filter-status').value;
+  let url = `${API}/secrets/findings?page=${page}&page_size=20`;
+  if (app) url += `&application_id=${app}`;
+  if (sev) url += `&severity=${sev}`;
+  if (sta) url += `&status=${sta}`;
+
+  const tbody = document.getElementById('findings-tbody');
+  tbody.innerHTML = '<tr><td colspan="7" style="text-align:center;padding:30px;color:#475569;">Loading...</td></tr>';
+
+  try {
+    const r = await fetch(url);
+    const d = await r.json();
+    renderFindings(d);
+  } catch(e) {
+    tbody.innerHTML = '<tr><td colspan="7" style="text-align:center;padding:30px;color:#f87171;">Failed to load findings</td></tr>';
+  }
+}
+
+function renderFindings(data) {
+  const tbody = document.getElementById('findings-tbody');
+  const items = data.items || [];
+
+  if (!items.length) {
+    tbody.innerHTML = '<tr><td colspan="7" style="text-align:center;padding:40px;color:#475569;">No secret findings found</td></tr>';
+    document.getElementById('findings-count').textContent = '';
+    document.getElementById('findings-pages').innerHTML = '';
+    return;
+  }
+
+  tbody.innerHTML = items.map(f => `
+    <tr class="table-row" style="border-bottom:1px solid rgba(255,255,255,0.04);">
+      <td style="padding:12px;">
+        <div style="font-size:13px;font-weight:500;color:#f1f5f9;max-width:280px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;" title="${esc(f.title)}">${esc(f.title)}</div>
+        <div style="font-size:11px;color:#475569;margin-top:2px;font-family:monospace;">${esc(f.rule_id || '')}</div>
+      </td>
+      <td style="padding:12px;font-size:13px;color:#94a3b8;">${esc(appsMap[f.application_id] || f.application_id?.slice(0,8) || '—')}</td>
+      <td style="padding:12px;">
+        <div style="font-size:12px;font-family:monospace;color:#64748b;max-width:200px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;" title="${esc(f.file_path || '')}">
+          ${f.file_path ? esc(f.file_path) + (f.line_number ? ':' + f.line_number : '') : '—'}
+        </div>
+      </td>
+      <td style="padding:12px;"><span class="badge badge-${f.severity}">${f.severity}</span></td>
+      <td style="padding:12px;"><span class="badge badge-${f.status}">${f.status.replace('_', ' ')}</span></td>
+      <td style="padding:12px;font-size:12px;color:#475569;">${timeAgo(f.first_seen_at)}</td>
+      <td style="padding:12px;text-align:right;">
+        <div style="display:flex;gap:6px;justify-content:flex-end;">
+          ${f.status === 'open' ? `
+            <button class="btn-secondary" onclick="updateFindingStatus('${f.id}','accepted')" style="padding:4px 10px;font-size:11px;">Accept</button>
+            <button class="btn-secondary" onclick="updateFindingStatus('${f.id}','false_positive')" style="padding:4px 10px;font-size:11px;">FP</button>
+          ` : `
+            <button class="btn-secondary" onclick="updateFindingStatus('${f.id}','open')" style="padding:4px 10px;font-size:11px;">Reopen</button>
+          `}
+        </div>
+      </td>
+    </tr>
+  `).join('');
+
+  document.getElementById('findings-count').textContent = `Showing ${items.length} of ${data.total} findings`;
+
+  const pagesEl = document.getElementById('findings-pages');
+  pagesEl.innerHTML = '';
+  for (let p = 1; p <= data.pages; p++) {
+    const btn = document.createElement('button');
+    btn.className = 'btn-secondary';
+    btn.textContent = p;
+    btn.style.padding = '4px 10px';
+    btn.style.minWidth = '32px';
+    if (p === data.page) { btn.style.background = 'rgba(0,212,255,0.15)'; btn.style.color = '#00d4ff'; }
+    btn.onclick = () => loadFindings(p);
+    pagesEl.appendChild(btn);
+  }
+
+  lucide.createIcons();
+}
+
+async function updateFindingStatus(id, status) {
+  try {
+    await fetch(`${API}/secrets/findings/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status }),
+    });
+    await Promise.all([loadFindings(currentFindingsPage), loadStats()]);
+  } catch(e) { alert('Failed to update status'); }
+}
+
+// -----------------------------------------------------------------------
+// Patterns
+// -----------------------------------------------------------------------
+async function loadPatterns() {
+  const tbody = document.getElementById('patterns-tbody');
+  tbody.innerHTML = '<tr><td colspan="5" style="text-align:center;padding:30px;color:#475569;">Loading...</td></tr>';
+  try {
+    const r = await fetch(`${API}/secrets/patterns?page_size=100`);
+    const d = await r.json();
+    renderPatterns(d.items || []);
+  } catch(e) {
+    tbody.innerHTML = '<tr><td colspan="5" style="text-align:center;padding:30px;color:#f87171;">Failed to load patterns</td></tr>';
+  }
+}
+
+function renderPatterns(patterns) {
+  const tbody = document.getElementById('patterns-tbody');
+  if (!patterns.length) {
+    tbody.innerHTML = '<tr><td colspan="5" style="text-align:center;padding:40px;color:#475569;">No custom patterns yet. Add one to detect organisation-specific secrets.</td></tr>';
+    return;
+  }
+  tbody.innerHTML = patterns.map(p => `
+    <tr class="table-row" style="border-bottom:1px solid rgba(255,255,255,0.04);">
+      <td style="padding:12px;">
+        <div style="font-size:13px;font-weight:500;color:#f1f5f9;">${esc(p.name)}</div>
+        ${p.description ? `<div style="font-size:11px;color:#475569;margin-top:2px;">${esc(p.description)}</div>` : ''}
+      </td>
+      <td style="padding:12px;"><code style="font-size:12px;color:#a5b4fc;background:rgba(99,102,241,0.1);padding:2px 6px;border-radius:4px;word-break:break-all;">${esc(p.pattern)}</code></td>
+      <td style="padding:12px;"><span class="badge badge-${p.severity}">${p.severity}</span></td>
+      <td style="padding:12px;">
+        <span style="font-size:12px;color:${p.is_active ? '#34d399' : '#475569'};">
+          ${p.is_active ? '● Active' : '○ Inactive'}
+        </span>
+      </td>
+      <td style="padding:12px;text-align:right;">
+        <div style="display:flex;gap:6px;justify-content:flex-end;">
+          <button class="btn-secondary" onclick='editPattern(${JSON.stringify(p)})' style="padding:4px 10px;font-size:11px;">
+            <i data-lucide="pencil" style="width:12px;height:12px;"></i> Edit
+          </button>
+          <button class="btn-danger" onclick="deletePattern('${p.id}','${esc(p.name)}')" style="padding:4px 10px;font-size:11px;">
+            <i data-lucide="trash-2" style="width:12px;height:12px;"></i>
+          </button>
+        </div>
+      </td>
+    </tr>
+  `).join('');
+  lucide.createIcons();
+}
+
+function openPatternModal(pattern = null) {
+  document.getElementById('modal-title').textContent = pattern ? 'Edit Pattern' : 'Add Custom Pattern';
+  document.getElementById('modal-pattern-id').value = pattern?.id || '';
+  document.getElementById('modal-name').value = pattern?.name || '';
+  document.getElementById('modal-pattern').value = pattern?.pattern || '';
+  document.getElementById('modal-description').value = pattern?.description || '';
+  document.getElementById('modal-severity').value = pattern?.severity || 'high';
+  document.getElementById('modal-active').checked = pattern ? pattern.is_active : true;
+  document.getElementById('modal-pattern-error').style.display = 'none';
+  document.getElementById('pattern-modal').style.display = 'flex';
+  lucide.createIcons();
+}
+
+function editPattern(p) { openPatternModal(p); }
+
+function closePatternModal() {
+  document.getElementById('pattern-modal').style.display = 'none';
+}
+
+function closePatternModalIfBackground(e) {
+  if (e.target === document.getElementById('pattern-modal')) closePatternModal();
+}
+
+function validateModalPattern() {
+  const val = document.getElementById('modal-pattern').value;
+  const errEl = document.getElementById('modal-pattern-error');
+  try {
+    new RegExp(val);
+    errEl.style.display = 'none';
+    return true;
+  } catch(e) {
+    errEl.textContent = 'Invalid regex: ' + e.message;
+    errEl.style.display = 'block';
+    return false;
+  }
+}
+
+async function savePattern() {
+  if (!validateModalPattern()) return;
+
+  const id = document.getElementById('modal-pattern-id').value;
+  const body = {
+    name: document.getElementById('modal-name').value.trim(),
+    pattern: document.getElementById('modal-pattern').value.trim(),
+    description: document.getElementById('modal-description').value.trim() || null,
+    severity: document.getElementById('modal-severity').value,
+    is_active: document.getElementById('modal-active').checked,
+  };
+
+  if (!body.name || !body.pattern) {
+    alert('Name and pattern are required');
+    return;
+  }
+
+  const btn = document.getElementById('modal-save-btn');
+  btn.disabled = true;
+  btn.innerHTML = '<div class="spinner"></div> Saving...';
+
+  try {
+    const method = id ? 'PUT' : 'POST';
+    const url = id ? `${API}/secrets/patterns/${id}` : `${API}/secrets/patterns`;
+    const r = await fetch(url, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!r.ok) {
+      const err = await r.json();
+      alert(err.detail || 'Save failed');
+      return;
+    }
+    closePatternModal();
+    await Promise.all([loadPatterns(), loadPatternCount()]);
+  } catch(e) {
+    alert('Save failed');
+  } finally {
+    btn.disabled = false;
+    btn.innerHTML = '<i data-lucide="save" style="width:14px;height:14px;"></i> Save Pattern';
+    lucide.createIcons();
+  }
+}
+
+async function deletePattern(id, name) {
+  if (!confirm(`Delete pattern "${name}"? This cannot be undone.`)) return;
+  try {
+    await fetch(`${API}/secrets/patterns/${id}`, { method: 'DELETE' });
+    await Promise.all([loadPatterns(), loadPatternCount()]);
+  } catch(e) { alert('Delete failed'); }
+}
+
+// -----------------------------------------------------------------------
+// Pattern tester
+// -----------------------------------------------------------------------
+async function runPatternTest() {
+  const pattern = document.getElementById('test-pattern-input').value.trim();
+  const sample = document.getElementById('test-sample-input').value;
+  const resultEl = document.getElementById('test-result');
+
+  if (!pattern) { alert('Enter a pattern to test'); return; }
+
+  try {
+    const r = await fetch(`${API}/secrets/patterns/test`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ pattern, sample_text: sample }),
+    });
+    const d = await r.json();
+    resultEl.style.display = 'block';
+    if (!d.valid) {
+      resultEl.innerHTML = `<div style="color:#f87171;font-size:13px;">Invalid regex: ${esc(d.error || '')}</div>`;
+    } else if (d.match_count === 0) {
+      resultEl.innerHTML = `<div style="color:#475569;font-size:13px;">No matches found.</div>`;
+    } else {
+      resultEl.innerHTML = `
+        <div style="color:#34d399;font-size:13px;margin-bottom:8px;">${d.match_count} match${d.match_count !== 1 ? 'es' : ''} found:</div>
+        <div style="display:flex;flex-wrap:wrap;gap:6px;">
+          ${d.matches.map(m => `<code style="background:rgba(0,212,255,0.1);color:#00d4ff;padding:2px 8px;border-radius:4px;font-size:12px;">${esc(m)}</code>`).join('')}
+        </div>
+      `;
+    }
+  } catch(e) {
+    resultEl.style.display = 'block';
+    resultEl.innerHTML = '<div style="color:#f87171;font-size:13px;">Request failed</div>';
+  }
+}
+
+function clearTestResult() {
+  document.getElementById('test-result').style.display = 'none';
+}
+
+// -----------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------
+function esc(s) {
+  return String(s ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+}
+
+function timeAgo(iso) {
+  if (!iso) return '—';
+  const diff = Date.now() - new Date(iso).getTime();
+  const m = Math.floor(diff / 60000);
+  if (m < 1) return 'just now';
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.floor(h / 24)}d ago`;
+}
+
+init();
+</script>
+</body>
+</html>

--- a/frontend/secrets.html
+++ b/frontend/secrets.html
@@ -460,13 +460,16 @@ async function loadPatterns() {
   }
 }
 
+let patternsData = [];
+
 function renderPatterns(patterns) {
+  patternsData = patterns;
   const tbody = document.getElementById('patterns-tbody');
   if (!patterns.length) {
     tbody.innerHTML = '<tr><td colspan="5" style="text-align:center;padding:40px;color:#475569;">No custom patterns yet. Add one to detect organisation-specific secrets.</td></tr>';
     return;
   }
-  tbody.innerHTML = patterns.map(p => `
+  tbody.innerHTML = patterns.map((p, idx) => `
     <tr class="table-row" style="border-bottom:1px solid rgba(255,255,255,0.04);">
       <td style="padding:12px;">
         <div style="font-size:13px;font-weight:500;color:#f1f5f9;">${esc(p.name)}</div>
@@ -481,10 +484,10 @@ function renderPatterns(patterns) {
       </td>
       <td style="padding:12px;text-align:right;">
         <div style="display:flex;gap:6px;justify-content:flex-end;">
-          <button class="btn-secondary" onclick='editPattern(${JSON.stringify(p)})' style="padding:4px 10px;font-size:11px;">
+          <button class="btn-secondary" onclick="editPatternByIdx(${idx})" style="padding:4px 10px;font-size:11px;">
             <i data-lucide="pencil" style="width:12px;height:12px;"></i> Edit
           </button>
-          <button class="btn-danger" onclick="deletePattern('${p.id}','${esc(p.name)}')" style="padding:4px 10px;font-size:11px;">
+          <button class="btn-danger" onclick="deletePatternByIdx(${idx})" style="padding:4px 10px;font-size:11px;">
             <i data-lucide="trash-2" style="width:12px;height:12px;"></i>
           </button>
         </div>
@@ -493,6 +496,8 @@ function renderPatterns(patterns) {
   `).join('');
   lucide.createIcons();
 }
+
+function editPatternByIdx(idx) { openPatternModal(patternsData[idx]); }
 
 function openPatternModal(pattern = null) {
   document.getElementById('modal-title').textContent = pattern ? 'Edit Pattern' : 'Add Custom Pattern';
@@ -506,8 +511,6 @@ function openPatternModal(pattern = null) {
   document.getElementById('pattern-modal').style.display = 'flex';
   lucide.createIcons();
 }
-
-function editPattern(p) { openPatternModal(p); }
 
 function closePatternModal() {
   document.getElementById('pattern-modal').style.display = 'none';
@@ -576,10 +579,11 @@ async function savePattern() {
   }
 }
 
-async function deletePattern(id, name) {
-  if (!confirm(`Delete pattern "${name}"? This cannot be undone.`)) return;
+async function deletePatternByIdx(idx) {
+  const p = patternsData[idx];
+  if (!confirm(`Delete pattern "${p.name}"? This cannot be undone.`)) return;
   try {
-    await fetch(`${API}/secrets/patterns/${id}`, { method: 'DELETE' });
+    await fetch(`${API}/secrets/patterns/${p.id}`, { method: 'DELETE' });
     await Promise.all([loadPatterns(), loadPatternCount()]);
   } catch(e) { alert('Delete failed'); }
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Gitleaks secrets scanning** — runs alongside Semgrep/Trivy in `scan_application_task`; raw secret values are never stored (masked to `****{last4}` in description); custom org-specific regex patterns stored in `SecretPattern` DB table and passed to gitleaks via a temp TOML `--config` at scan time
- **Policy engine** — `Policy` model + `policy_evaluator` service; policies evaluated after every scan with configurable severity thresholds, scan type filters, rule block/allowlists, and `inform`/`block` actions
- **Secrets UI** (`secrets.html`) — dedicated page with Findings tab (filterable by app/severity/status, accept/false-positive actions) and Custom Patterns tab (CRUD + inline regex tester)
- **Policies UI** (`policies.html`) — full policy management page
- Secrets nav link added to all existing pages
- Removed Seed Demo Data button from dashboard
- README and CLAUDE.md updated

## New API endpoints

- `GET/PATCH /api/v1/secrets/findings` — secrets-specific finding list and status updates
- `GET /api/v1/secrets/findings/stats` — counts by severity and rule
- `GET/POST/PUT/DELETE /api/v1/secrets/patterns` — custom Gitleaks pattern CRUD
- `POST /api/v1/secrets/patterns/test` — validate regex against sample text
- `GET/POST/PATCH/DELETE /api/v1/policies` — policy CRUD
- `POST /api/v1/policies/{id}/evaluate` — evaluate policy against live findings

## New DB migrations

- `004_add_policies_table` — `policies` table
- `005_add_secret_patterns_table` — `secret_patterns` table

## Test plan

- [ ] `cd backend && python -m pytest tests/ -v` — all tests pass
- [ ] `docker compose up --build && alembic upgrade head`
- [ ] Trigger a scan — verify gitleaks findings appear under `/api/v1/secrets/findings`
- [ ] Add a custom pattern via `POST /api/v1/secrets/patterns`, retrigger scan — verify pattern fires
- [ ] Open `secrets.html` — findings table loads, pattern CRUD works, test-pattern inline tester returns matches
- [ ] Create a policy, trigger a scan — verify policy evaluation result in task return value

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)