### PR TITLE
Fix PR #12 review comments: sidebar theming and profile page bugs

### DIFF
--- a/frontend/policies.html
+++ b/frontend/policies.html
@@ -63,7 +63,7 @@
 <script>(function(){var t=localStorage.getItem('theme')||'dark';document.documentElement.setAttribute('data-theme',t);window.applyTheme=function(theme){document.documentElement.setAttribute('data-theme',theme);var light=theme==='light';var sb=document.getElementById('sidebar');if(sb)sb.style.background=light?'#1e293b':'#080c18';document.body.style.background=light?'#f0f4f8':'#0a0e1a';var mc=document.getElementById('main-content');if(mc)mc.style.background=light?'#f0f4f8':'#0a0e1a';};})();</script>
 
   <!-- Sidebar -->
-  <aside style="width:260px;min-height:100vh;background:#080c18;border-right:1px solid rgba(255,255,255,0.08);display:flex;flex-direction:column;position:fixed;left:0;top:0;z-index:100;">
+  <aside id="sidebar" style="width:260px;min-height:100vh;background:#080c18;border-right:1px solid rgba(255,255,255,0.08);display:flex;flex-direction:column;position:fixed;left:0;top:0;z-index:100;">
     <div style="padding:24px 20px;border-bottom:1px solid rgba(255,255,255,0.08);display:flex;align-items:center;gap:12px;">
       <div style="width:40px;height:40px;background:linear-gradient(135deg,#00d4ff22,#6366f122);border:1px solid #00d4ff44;border-radius:12px;display:flex;align-items:center;justify-content:center;">
         <i data-lucide="shield-alert" style="width:20px;height:20px;color:#00d4ff;"></i>

--- a/frontend/profile.html
+++ b/frontend/profile.html
@@ -167,7 +167,7 @@
 
         <div id="token-warning" style="display:none;margin-top:14px;padding:12px 16px;background:rgba(245,158,11,0.1);border:1px solid rgba(245,158,11,0.25);border-radius:10px;font-size:13px;color:#f59e0b;">
           <i data-lucide="alert-triangle" style="width:14px;height:14px;display:inline;vertical-align:middle;margin-right:6px;"></i>
-          Copy this token now — it won't be shown again after you leave this page.
+          Copy this token now — it remains available on this device until you generate a new one.
         </div>
       </div>
 
@@ -343,7 +343,7 @@ function saveNotifPref() {
 
   // Request browser notification permission if any toggle enabled
   const anyEnabled = Object.values(prefs).some(Boolean);
-  if (anyEnabled && Notification.permission === 'default') {
+  if (anyEnabled && typeof Notification !== 'undefined' && Notification.permission === 'default') {
     Notification.requestPermission();
   }
 }

--- a/frontend/repositories.html
+++ b/frontend/repositories.html
@@ -32,7 +32,7 @@
 <script>(function(){var t=localStorage.getItem('theme')||'dark';document.documentElement.setAttribute('data-theme',t);window.applyTheme=function(theme){document.documentElement.setAttribute('data-theme',theme);var light=theme==='light';var sb=document.getElementById('sidebar');if(sb)sb.style.background=light?'#1e293b':'#080c18';document.body.style.background=light?'#f0f4f8':'#0a0e1a';};})();</script>
 
   <!-- Sidebar -->
-  <aside style="width:260px;min-height:100vh;background:#080c18;border-right:1px solid rgba(255,255,255,0.08);display:flex;flex-direction:column;position:fixed;left:0;top:0;z-index:100;">
+  <aside id="sidebar" style="width:260px;min-height:100vh;background:#080c18;border-right:1px solid rgba(255,255,255,0.08);display:flex;flex-direction:column;position:fixed;left:0;top:0;z-index:100;">
     <div style="padding:24px 20px;border-bottom:1px solid rgba(255,255,255,0.08);display:flex;align-items:center;gap:12px;">
       <div style="width:40px;height:40px;background:linear-gradient(135deg,#00d4ff22,#6366f122);border:1px solid #00d4ff44;border-radius:12px;display:flex;align-items:center;justify-content:center;">
         <i data-lucide="shield-alert" style="width:20px;height:20px;color:#00d4ff;"></i>

--- a/frontend/secrets.html
+++ b/frontend/secrets.html
@@ -46,7 +46,7 @@
 <script>(function(){var t=localStorage.getItem('theme')||'dark';document.documentElement.setAttribute('data-theme',t);window.applyTheme=function(theme){document.documentElement.setAttribute('data-theme',theme);var light=theme==='light';var sb=document.getElementById('sidebar');if(sb)sb.style.background=light?'#1e293b':'#080c18';document.body.style.background=light?'#f0f4f8':'#0a0e1a';var mc=document.getElementById('main-content');if(mc)mc.style.background=light?'#f0f4f8':'#0a0e1a';};})();</script>
 
   <!-- Sidebar -->
-  <aside style="width:260px;min-height:100vh;background:#080c18;border-right:1px solid rgba(255,255,255,0.08);display:flex;flex-direction:column;position:fixed;left:0;top:0;z-index:100;">
+  <aside id="sidebar" style="width:260px;min-height:100vh;background:#080c18;border-right:1px solid rgba(255,255,255,0.08);display:flex;flex-direction:column;position:fixed;left:0;top:0;z-index:100;">
     <div style="padding:24px 20px;border-bottom:1px solid rgba(255,255,255,0.08);display:flex;align-items:center;gap:12px;">
       <div style="width:40px;height:40px;background:linear-gradient(135deg,#00d4ff22,#6366f122);border:1px solid #00d4ff44;border-radius:12px;display:flex;align-items:center;justify-content:center;">
         <i data-lucide="shield-alert" style="width:20px;height:20px;color:#00d4ff;"></i>


### PR DESCRIPTION
## Summary
- Add `id="sidebar"` to `<aside>` in `policies.html`, `secrets.html`, and `repositories.html` — the light-mode `applyTheme()` script was already targeting `#sidebar` but these three pages were missing the id, so the sidebar background never switched in light mode
- Guard `Notification.permission` in `profile.html` with `typeof Notification !== 'undefined'` to prevent a JS throw in browsers/environments without the Notifications API
- Fix misleading token warning copy: the token is persisted in `localStorage` and re-shown on return, so "won't be shown again after you leave" was inaccurate

## Test plan
- [ ] Toggle to light mode on `/policies.html`, `/secrets.html`, `/repositories.html` — sidebar should switch to `#1e293b`
- [ ] Open `/profile.html` in a browser with notifications blocked — no JS error thrown when toggling notification preferences

🤖 Generated with [Claude Code](https://claude.com/claude-code)