### PR TITLE
Fix issue #13: nav consistency and light mode sidebar

### DIFF
--- a/frontend/repositories.html
+++ b/frontend/repositories.html
@@ -43,7 +43,7 @@
       </div>
     </div>
     <nav style="padding:12px 12px;flex:1;">
-      <div style="font-size:10px;color:#475569;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;padding:4px 8px 8px;">Platform</div>
+      <div style="font-size:10px;color:#475569;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;padding:8px 8px 4px;">Main Menu</div>
       <a href="/" class="nav-link" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;color:#94a3b8;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;">
         <i data-lucide="layout-dashboard" style="width:18px;height:18px;"></i> Dashboard
       </a>
@@ -77,7 +77,7 @@
     <div style="padding:16px 20px;border-top:1px solid rgba(255,255,255,0.08);">
       <div style="display:flex;align-items:center;gap:8px;">
         <div style="width:8px;height:8px;background:#10b981;border-radius:50%;box-shadow:0 0 8px #10b981;"></div>
-        <span style="font-size:12px;color:#64748b;">System Online</span>
+        <span style="font-size:12px;color:#64748b;">All systems operational</span>
       </div>
     </div>
   </aside>

--- a/frontend/rules.html
+++ b/frontend/rules.html
@@ -66,7 +66,7 @@
 <body style="font-family:'Inter',sans-serif;background:#0a0e1a;color:#f1f5f9;margin:0;padding:0;min-height:100vh;">
 
   <!-- Sidebar -->
-  <aside style="width:260px;min-height:100vh;background:#080c18;border-right:1px solid rgba(255,255,255,0.08);display:flex;flex-direction:column;position:fixed;left:0;top:0;z-index:100;">
+  <aside id="sidebar" style="width:260px;min-height:100vh;background:#080c18;border-right:1px solid rgba(255,255,255,0.08);display:flex;flex-direction:column;position:fixed;left:0;top:0;z-index:100;">
     <div style="padding:24px 20px;border-bottom:1px solid rgba(255,255,255,0.08);display:flex;align-items:center;gap:12px;">
       <div style="width:40px;height:40px;background:linear-gradient(135deg,#00d4ff22,#6366f122);border:1px solid #00d4ff44;border-radius:12px;display:flex;align-items:center;justify-content:center;">
         <i data-lucide="shield-alert" style="width:20px;height:20px;color:#00d4ff;"></i>
@@ -93,11 +93,14 @@
       <a href="/policies.html" class="nav-link" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;color:#94a3b8;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;">
         <i data-lucide="shield-check" style="width:18px;height:18px;"></i> Policies
       </a>
+      <a href="/secrets.html" class="nav-link" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;color:#94a3b8;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;">
+        <i data-lucide="key" style="width:18px;height:18px;"></i> Secrets
+      </a>
       <a href="/rules.html" class="nav-link" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;background:linear-gradient(135deg,rgba(0,212,255,0.15),rgba(99,102,241,0.15));color:#00d4ff;border:1px solid rgba(0,212,255,0.2);">
         <i data-lucide="book-open" style="width:18px;height:18px;"></i> Rules
       </a>
-      <a href="/secrets.html" class="nav-link" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;color:#94a3b8;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;">
-        <i data-lucide="key" style="width:18px;height:18px;"></i> Secrets
+      <a href="/profile.html" class="nav-link" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;color:#94a3b8;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;">
+        <i data-lucide="user" style="width:18px;height:18px;"></i> Profile
       </a>
       <div style="font-size:10px;color:#475569;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;padding:16px 8px 4px;">Developer</div>
       <a href="/docs" class="nav-link" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;color:#94a3b8;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;">

--- a/frontend/static/css/theme.css
+++ b/frontend/static/css/theme.css
@@ -40,11 +40,24 @@
   --scrollbar-thumb: rgba(0,0,0,0.15);
 }
 
-/* ---- CSS class overrides ---- */
+/* ---- Base element overrides ---- */
 
 [data-theme="light"] body {
+  background: var(--bg-page) !important;
   color: var(--text-primary);
 }
+
+[data-theme="light"] aside {
+  background: var(--bg-sidebar) !important;
+  border-color: var(--border-color) !important;
+}
+
+[data-theme="light"] header {
+  background: rgba(30,41,59,0.95) !important;
+  border-color: rgba(255,255,255,0.1) !important;
+}
+
+/* ---- CSS class overrides ---- */
 
 [data-theme="light"] .card {
   background: var(--bg-card) !important;


### PR DESCRIPTION
## Summary
Fixes [issue #13](https://github.com/andrewblooman/snitch/issues/13).

- **Light mode sidebar stays dark** — `theme.css` now drives `aside` and `body` background via CSS (`[data-theme="light"] aside` / `body`), so light mode applies correctly on initial page load without needing `applyTheme()` to be called. Previously only JS set the sidebar colour, so a hard refresh in light mode left the sidebar dark.
- **`rules.html` nav broken** — added missing `id="sidebar"`, corrected nav order (Secrets was after Rules; now matches all other pages: Policies → Secrets → Rules → Profile), added missing Profile link.
- **`repositories.html` inconsistencies** — section header was "Platform" (now "Main Menu"), footer text was "System Online" (now "All systems operational").

## Test plan
- [ ] Set theme to Light on `/profile.html`, then hard-refresh each page — sidebar should be slate-blue (`#1e293b`), not dark
- [ ] Visit `/rules.html` — nav order should be: Dashboard, Applications, Repositories, Reports, Policies, Secrets, **Rules** (active), Profile, API Docs
- [ ] Visit `/repositories.html` — section header "Main Menu", footer "All systems operational"

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)