### PR TITLE
Add vibrant severity palette and atmospheric UI styling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,13 +5,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Rules
 
 ALWAYS update CLAUDE.md before pushing any code to GitHub
+ALWAYS update README.md before pushing any code to GitHub
+ALWAYS update API Docs / swagger before pushing any code to GitHub
 ALWAYS check for multiple branches and question whether any branches other than main can be deleted
 ALWAYS create a new branch before starting any new work
 ALWAYS push the branch to GitHub and open a PR
 
 ## What This Is
 
-Snitch is an AppSec platform that aggregates security findings from Semgrep (SAST), Grype (container CVEs), Trivy (SCA), and Gitleaks (secrets), calculates per-app risk scores, and provides AI-powered remediation via Anthropic Claude. Includes a User Profile page with light/dark mode toggle (stored in localStorage).
+Snitch is an AppSec platform that aggregates security findings from Semgrep (SAST), Grype (container CVEs), Trivy (SCA), and Gitleaks (secrets), calculates per-app risk scores, and provides AI-powered remediation via Anthropic Claude. Includes a User Profile page with light/dark mode toggle (stored in localStorage). UI uses a vibrant dark theme with CSS design tokens in `frontend/static/css/theme.css` (severity palette, gradient, glow variables).
 
 ## Commands
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -15,27 +15,28 @@
     @keyframes pulse { 0%,100%{opacity:1} 50%{opacity:0.5} }
     @keyframes fadeInUp { from{transform:translateY(20px);opacity:0} to{transform:translateY(0);opacity:1} }
     @keyframes spin { to{transform:rotate(360deg)} }
-    @keyframes glow { 0%,100%{box-shadow:0 0 20px rgba(0,212,255,0.3)} 50%{box-shadow:0 0 40px rgba(0,212,255,0.6)} }
+    @keyframes iconGlow { 0%,100%{filter:brightness(1)} 50%{filter:brightness(1.25)} }
     .nav-link:hover { background:rgba(255,255,255,0.05) !important; color:#e2e8f0 !important; }
-    .card-hover:hover { border-color:rgba(0,212,255,0.3) !important; transform:translateY(-2px); transition:all 0.3s; }
-    .btn-primary { background:linear-gradient(135deg,#00d4ff,#6366f1);color:white;border:none;padding:10px 20px;border-radius:10px;font-weight:600;font-size:14px;cursor:pointer;transition:all 0.2s;display:inline-flex;align-items:center;gap:8px; }
-    .btn-primary:hover { transform:translateY(-1px);box-shadow:0 4px 20px rgba(0,212,255,0.4); }
+    .card-hover:hover { border-color:rgba(0,212,255,0.3) !important; transform:translateY(-2px); box-shadow:0 8px 32px rgba(0,212,255,0.08); transition:all 0.3s; }
+    .btn-primary { background:linear-gradient(135deg,#00d4ff,#7c3aed);color:white;border:none;padding:10px 20px;border-radius:10px;font-weight:600;font-size:14px;cursor:pointer;transition:all 0.2s;display:inline-flex;align-items:center;gap:8px; }
+    .btn-primary:hover { transform:translateY(-1px);box-shadow:0 4px 24px rgba(0,212,255,0.35); }
     .btn-secondary { background:rgba(255,255,255,0.05);color:#94a3b8;border:1px solid rgba(255,255,255,0.1);padding:10px 20px;border-radius:10px;font-weight:500;font-size:14px;cursor:pointer;transition:all 0.2s; }
     .btn-secondary:hover { background:rgba(255,255,255,0.1);color:#f1f5f9; }
     .table-row:hover { background:rgba(255,255,255,0.03) !important; }
-    .card { background:rgba(13,17,23,0.8);border:1px solid rgba(255,255,255,0.08);border-radius:16px;backdrop-filter:blur(20px); }
+    .card { background:rgba(13,17,35,0.8);border:1px solid rgba(255,255,255,0.08);border-radius:16px;backdrop-filter:blur(20px); }
+    .stat-icon { animation: iconGlow 3s ease-in-out infinite; }
     ::-webkit-scrollbar { width:6px; height:6px; }
     ::-webkit-scrollbar-track { background:rgba(255,255,255,0.02); }
     ::-webkit-scrollbar-thumb { background:rgba(255,255,255,0.1);border-radius:3px; }
   </style>
 </head>
-<body style="font-family:'Inter',sans-serif;background:#0a0e1a;color:#f1f5f9;margin:0;padding:0;min-height:100vh;">
-<script>(function(){var t=localStorage.getItem('theme')||'dark';document.documentElement.setAttribute('data-theme',t);window.applyTheme=function(theme){document.documentElement.setAttribute('data-theme',theme);var light=theme==='light';var sb=document.getElementById('sidebar');if(sb)sb.style.background=light?'#1e293b':'#080c18';document.body.style.background=light?'#f0f4f8':'#0a0e1a';var mc=document.getElementById('main-content');if(mc)mc.style.background=light?'#f0f4f8':'#0a0e1a';};})();</script>
+<body style="font-family:'Inter',sans-serif;margin:0;padding:0;min-height:100vh;">
+<script>(function(){var t=localStorage.getItem('theme')||'dark';document.documentElement.setAttribute('data-theme',t);window.applyTheme=function(theme){document.documentElement.setAttribute('data-theme',theme);var light=theme==='light';var sb=document.getElementById('sidebar');if(sb)sb.style.background=light?'#1e293b':'#080c18';document.body.style.background='';var mc=document.getElementById('main-content');if(mc)mc.style.background='';};})();</script>
 
   <!-- Sidebar -->
   <aside id="sidebar" style="width:260px;min-height:100vh;background:#080c18;border-right:1px solid rgba(255,255,255,0.08);display:flex;flex-direction:column;position:fixed;left:0;top:0;z-index:100;">
     <div style="padding:24px 20px;border-bottom:1px solid rgba(255,255,255,0.08);display:flex;align-items:center;gap:12px;">
-      <div style="width:40px;height:40px;background:linear-gradient(135deg,#00d4ff22,#6366f122);border:1px solid #00d4ff44;border-radius:12px;display:flex;align-items:center;justify-content:center;">
+      <div style="width:40px;height:40px;background:linear-gradient(135deg,rgba(0,212,255,0.2),rgba(124,58,237,0.2));border:1px solid rgba(0,212,255,0.45);border-radius:12px;display:flex;align-items:center;justify-content:center;box-shadow:0 0 16px rgba(0,212,255,0.15);">
         <i data-lucide="shield-alert" style="width:20px;height:20px;color:#00d4ff;"></i>
       </div>
       <div>
@@ -85,7 +86,7 @@
 
   <!-- Main -->
   <div id="main-content" style="margin-left:260px;min-height:100vh;">
-    <header style="background:rgba(8,12,24,0.9);backdrop-filter:blur(20px);border-bottom:1px solid rgba(255,255,255,0.08);padding:16px 32px;display:flex;align-items:center;justify-content:space-between;position:sticky;top:0;z-index:50;">
+    <header style="background:rgba(8,12,24,0.92);backdrop-filter:blur(20px);border-bottom:1px solid rgba(255,255,255,0.06);box-shadow:0 1px 0 0 rgba(0,212,255,0.12),0 4px 24px rgba(0,0,0,0.4);padding:16px 32px;display:flex;align-items:center;justify-content:space-between;position:sticky;top:0;z-index:50;">
       <div>
         <h1 style="font-size:22px;font-weight:700;color:#f1f5f9;margin:0;">Security Overview</h1>
         <p style="font-size:13px;color:#475569;margin:2px 0 0;">Real-time application security monitoring</p>
@@ -150,9 +151,9 @@
                   <th style="text-align:left;padding:8px 12px;font-size:11px;font-weight:600;color:#475569;text-transform:uppercase;letter-spacing:0.8px;">Application</th>
                   <th style="text-align:left;padding:8px 12px;font-size:11px;font-weight:600;color:#475569;text-transform:uppercase;letter-spacing:0.8px;">Team</th>
                   <th style="text-align:center;padding:8px 12px;font-size:11px;font-weight:600;color:#475569;text-transform:uppercase;letter-spacing:0.8px;">Risk</th>
-                  <th style="text-align:center;padding:8px 12px;font-size:11px;font-weight:600;color:#ef4444;text-transform:uppercase;letter-spacing:0.8px;">C</th>
-                  <th style="text-align:center;padding:8px 12px;font-size:11px;font-weight:600;color:#f59e0b;text-transform:uppercase;letter-spacing:0.8px;">H</th>
-                  <th style="text-align:center;padding:8px 12px;font-size:11px;font-weight:600;color:#f97316;text-transform:uppercase;letter-spacing:0.8px;">M</th>
+                  <th style="text-align:center;padding:8px 12px;font-size:11px;font-weight:600;color:#ff4757;text-transform:uppercase;letter-spacing:0.8px;">C</th>
+                  <th style="text-align:center;padding:8px 12px;font-size:11px;font-weight:600;color:#ff9f43;text-transform:uppercase;letter-spacing:0.8px;">H</th>
+                  <th style="text-align:center;padding:8px 12px;font-size:11px;font-weight:600;color:#ff6b35;text-transform:uppercase;letter-spacing:0.8px;">M</th>
                   <th style="text-align:left;padding:8px 12px;font-size:11px;font-weight:600;color:#475569;text-transform:uppercase;letter-spacing:0.8px;">Last Scan</th>
                 </tr>
               </thead>
@@ -196,29 +197,29 @@ function animateCounter(el, target, duration=1500, prefix='', suffix='') {
 }
 
 function getRiskColor(score) {
-  if (score >= 75) return '#ef4444';
-  if (score >= 50) return '#f59e0b';
-  if (score >= 25) return '#f97316';
+  if (score >= 75) return '#ff4757';
+  if (score >= 50) return '#ff9f43';
+  if (score >= 25) return '#ff6b35';
   return '#10b981';
 }
 
 function getRiskLevel(score) {
-  if (score >= 75) return {label:'Critical', color:'#ef4444', bg:'rgba(239,68,68,0.15)'};
-  if (score >= 50) return {label:'High', color:'#f59e0b', bg:'rgba(245,158,11,0.15)'};
-  if (score >= 25) return {label:'Medium', color:'#f97316', bg:'rgba(249,115,22,0.15)'};
-  return {label:'Low', color:'#10b981', bg:'rgba(16,185,129,0.15)'};
+  if (score >= 75) return {label:'Critical', color:'#ff4757', bg:'rgba(255,71,87,0.13)'};
+  if (score >= 50) return {label:'High', color:'#ff9f43', bg:'rgba(255,159,67,0.13)'};
+  if (score >= 25) return {label:'Medium', color:'#ff6b35', bg:'rgba(255,107,53,0.13)'};
+  return {label:'Low', color:'#10b981', bg:'rgba(16,185,129,0.13)'};
 }
 
 function severityBadge(sev) {
   const map = {
-    critical: {color:'#ef4444', bg:'rgba(239,68,68,0.15)', label:'Critical'},
-    high: {color:'#f59e0b', bg:'rgba(245,158,11,0.15)', label:'High'},
-    medium: {color:'#f97316', bg:'rgba(249,115,22,0.15)', label:'Medium'},
-    low: {color:'#3b82f6', bg:'rgba(59,130,246,0.15)', label:'Low'},
-    info: {color:'#94a3b8', bg:'rgba(148,163,184,0.15)', label:'Info'},
+    critical: {color:'#ff4757', bg:'rgba(255,71,87,0.13)', border:'rgba(255,71,87,0.35)', label:'Critical'},
+    high:     {color:'#ff9f43', bg:'rgba(255,159,67,0.13)', border:'rgba(255,159,67,0.35)', label:'High'},
+    medium:   {color:'#ff6b35', bg:'rgba(255,107,53,0.13)', border:'rgba(255,107,53,0.35)', label:'Medium'},
+    low:      {color:'#54a0ff', bg:'rgba(84,160,255,0.13)', border:'rgba(84,160,255,0.35)', label:'Low'},
+    info:     {color:'#a29bfe', bg:'rgba(162,155,254,0.13)', border:'rgba(162,155,254,0.35)', label:'Info'},
   };
   const s = map[sev?.toLowerCase()] || map.info;
-  return `<span style="background:${s.bg};color:${s.color};border:1px solid ${s.color}44;padding:2px 8px;border-radius:6px;font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:0.5px;">${s.label}</span>`;
+  return `<span style="background:${s.bg};color:${s.color};border:1px solid ${s.border};padding:2px 8px;border-radius:6px;font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:0.5px;">${s.label}</span>`;
 }
 
 function timeAgo(dateStr) {
@@ -231,7 +232,7 @@ function timeAgo(dateStr) {
 }
 
 function showToast(message, type='success') {
-  const colors = {success:'#10b981', error:'#ef4444', warning:'#f59e0b', info:'#00d4ff'};
+  const colors = {success:'#10b981', error:'#ff4757', warning:'#ff9f43', info:'#00d4ff'};
   const icons = {success:'check-circle', error:'alert-circle', warning:'alert-triangle', info:'info'};
   const toast = document.createElement('div');
   toast.style.cssText = `position:fixed;bottom:24px;right:24px;z-index:9999;background:rgba(13,17,23,0.95);border:1px solid ${colors[type]}44;border-left:3px solid ${colors[type]};padding:14px 18px;border-radius:10px;display:flex;align-items:center;gap:10px;color:#f1f5f9;font-size:14px;font-weight:500;backdrop-filter:blur(20px);box-shadow:0 8px 32px rgba(0,0,0,0.5);animation:slideInRight 0.3s ease;`;
@@ -256,7 +257,7 @@ function renderSeverityChart(data) {
   const ctx = document.getElementById('severityChart').getContext('2d');
   const labels = ['Critical','High','Medium','Low','Info'];
   const values = [data.critical||0, data.high||0, data.medium||0, data.low||0, data.info||0];
-  const colors = ['#ef4444','#f59e0b','#f97316','#3b82f6','#94a3b8'];
+  const colors = ['#ff4757','#ff9f43','#ff6b35','#54a0ff','#a29bfe'];
   const total = values.reduce((a,b)=>a+b,0);
   document.getElementById('total-findings-center').textContent = total.toLocaleString();
 
@@ -288,8 +289,8 @@ function renderRiskChart(data) {
       labels: ['Critical','High','Medium','Low'],
       datasets:[{
         data: [data.critical||0, data.high||0, data.medium||0, data.low||0],
-        backgroundColor: ['rgba(239,68,68,0.7)','rgba(245,158,11,0.7)','rgba(249,115,22,0.7)','rgba(16,185,129,0.7)'],
-        borderColor: ['#ef4444','#f59e0b','#f97316','#10b981'],
+        backgroundColor: ['rgba(255,71,87,0.7)','rgba(255,159,67,0.7)','rgba(255,107,53,0.7)','rgba(16,185,129,0.7)'],
+        borderColor: ['#ff4757','#ff9f43','#ff6b35','#10b981'],
         borderWidth: 2,
         borderRadius: 8,
         borderSkipped: false,
@@ -311,15 +312,15 @@ function renderRiskChart(data) {
 function renderStats(d) {
   const row = document.getElementById('stats-row');
   const stats = [
-    { label:'Total Applications', value:d.total_apps||0, icon:'layers', color:'#00d4ff', gradient:'rgba(0,212,255,0.15)', border:'rgba(0,212,255,0.3)', trend:'+2 this week', suffix:'' },
-    { label:'Critical Findings', value:d.critical_findings||0, icon:'alert-triangle', color:'#ef4444', gradient:'rgba(239,68,68,0.15)', border:'rgba(239,68,68,0.3)', trend:'+5 this week', suffix:'' },
-    { label:'Open Findings', value:d.open_findings||0, icon:'shield-alert', color:'#f97316', gradient:'rgba(249,115,22,0.15)', border:'rgba(249,115,22,0.3)', trend:'+12 this week', suffix:'' },
-    { label:'Avg Risk Score', value:Math.round(d.avg_risk_score||0), icon:'activity', color:'#6366f1', gradient:'rgba(99,102,241,0.15)', border:'rgba(99,102,241,0.3)', trend:'-3 this week', suffix:'/100' },
+    { label:'Total Applications', value:d.total_apps||0, icon:'layers', color:'#00d4ff', gradient:'linear-gradient(135deg,rgba(0,212,255,0.2),rgba(0,212,255,0.05))', border:'rgba(0,212,255,0.4)', glow:'rgba(0,212,255,0.15)', trend:'+2 this week', suffix:'' },
+    { label:'Critical Findings', value:d.critical_findings||0, icon:'alert-triangle', color:'#ff4757', gradient:'linear-gradient(135deg,rgba(255,71,87,0.22),rgba(255,71,87,0.05))', border:'rgba(255,71,87,0.4)', glow:'rgba(255,71,87,0.15)', trend:'+5 this week', suffix:'' },
+    { label:'Open Findings', value:d.open_findings||0, icon:'shield-alert', color:'#ff9f43', gradient:'linear-gradient(135deg,rgba(255,159,67,0.22),rgba(255,159,67,0.05))', border:'rgba(255,159,67,0.4)', glow:'rgba(255,159,67,0.15)', trend:'+12 this week', suffix:'' },
+    { label:'Avg Risk Score', value:Math.round(d.avg_risk_score||0), icon:'activity', color:'#a29bfe', gradient:'linear-gradient(135deg,rgba(162,155,254,0.22),rgba(124,58,237,0.05))', border:'rgba(162,155,254,0.4)', glow:'rgba(162,155,254,0.15)', trend:'-3 this week', suffix:'/100' },
   ];
   row.innerHTML = stats.map((s,i) => `
     <div class="card card-hover" style="padding:24px;animation:fadeInUp 0.5s ease both;animation-delay:${i*0.1}s;">
       <div style="display:flex;align-items:flex-start;justify-content:space-between;margin-bottom:16px;">
-        <div style="width:44px;height:44px;background:${s.gradient};border:1px solid ${s.border};border-radius:12px;display:flex;align-items:center;justify-content:center;">
+        <div class="stat-icon" style="width:44px;height:44px;background:${s.gradient};border:1px solid ${s.border};border-radius:12px;display:flex;align-items:center;justify-content:center;box-shadow:0 0 16px ${s.glow};">
           <i data-lucide="${s.icon}" style="width:22px;height:22px;color:${s.color};"></i>
         </div>
         <span style="font-size:11px;color:#475569;font-weight:500;background:rgba(255,255,255,0.03);padding:4px 8px;border-radius:6px;border:1px solid rgba(255,255,255,0.06);">Live</span>
@@ -373,9 +374,9 @@ function renderAppsTable(items) {
         <td style="padding:12px 12px;text-align:center;">
           <span style="background:${risk.bg};color:${risk.color};border:1px solid ${risk.color}44;padding:3px 10px;border-radius:8px;font-size:12px;font-weight:700;">${app.risk_score||0}/100</span>
         </td>
-        <td style="padding:12px 12px;text-align:center;font-size:13px;font-weight:600;color:${c > 0 ? '#ef4444' : '#475569'};">${c}</td>
-        <td style="padding:12px 12px;text-align:center;font-size:13px;font-weight:600;color:${h > 0 ? '#f59e0b' : '#475569'};">${h}</td>
-        <td style="padding:12px 12px;text-align:center;font-size:13px;font-weight:600;color:${m > 0 ? '#f97316' : '#475569'};">${m}</td>
+        <td style="padding:12px 12px;text-align:center;font-size:13px;font-weight:600;color:${c > 0 ? '#ff4757' : '#475569'};">${c}</td>
+        <td style="padding:12px 12px;text-align:center;font-size:13px;font-weight:600;color:${h > 0 ? '#ff9f43' : '#475569'};">${h}</td>
+        <td style="padding:12px 12px;text-align:center;font-size:13px;font-weight:600;color:${m > 0 ? '#ff6b35' : '#475569'};">${m}</td>
         <td style="padding:12px 12px;font-size:12px;color:#475569;">${timeAgo(app.last_scan_at)}</td>
       </tr>
     `;

--- a/frontend/static/css/theme.css
+++ b/frontend/static/css/theme.css
@@ -1,21 +1,48 @@
 /* Snitch theme tokens — dark (default) and light */
 
 :root {
+  /* ── Backgrounds ── */
   --bg-page: #0a0e1a;
   --bg-sidebar: #080c18;
-  --bg-card: rgba(255,255,255,0.03);
-  --bg-card-hover: rgba(255,255,255,0.05);
+  --bg-card: rgba(13,17,35,0.8);
+  --bg-card-hover: rgba(15,20,42,0.9);
   --bg-input: #0d1117;
   --bg-modal: #0d1117;
   --bg-table-header: rgba(255,255,255,0.03);
+  /* ── Text ── */
   --text-primary: #f1f5f9;
   --text-secondary: #94a3b8;
   --text-tertiary: #475569;
+  /* ── Borders ── */
   --border-color: rgba(255,255,255,0.08);
   --border-subtle: rgba(255,255,255,0.05);
+  /* ── Accent (cyan) ── */
   --accent: #00d4ff;
   --accent-dim: rgba(0,212,255,0.15);
-  --accent-border: rgba(0,212,255,0.2);
+  --accent-border: rgba(0,212,255,0.25);
+  /* ── Severity palette ── */
+  --sev-critical: #ff4757;
+  --sev-critical-bg: rgba(255,71,87,0.13);
+  --sev-critical-border: rgba(255,71,87,0.35);
+  --sev-high: #ff9f43;
+  --sev-high-bg: rgba(255,159,67,0.13);
+  --sev-high-border: rgba(255,159,67,0.35);
+  --sev-medium: #ff6b35;
+  --sev-medium-bg: rgba(255,107,53,0.13);
+  --sev-medium-border: rgba(255,107,53,0.35);
+  --sev-low: #54a0ff;
+  --sev-low-bg: rgba(84,160,255,0.13);
+  --sev-low-border: rgba(84,160,255,0.35);
+  --sev-info: #a29bfe;
+  --sev-info-bg: rgba(162,155,254,0.13);
+  --sev-info-border: rgba(162,155,254,0.35);
+  /* ── Gradients ── */
+  --gradient-brand: linear-gradient(135deg, #00d4ff 0%, #7c3aed 100%);
+  --gradient-brand-subtle: linear-gradient(135deg, rgba(0,212,255,0.15) 0%, rgba(124,58,237,0.15) 100%);
+  /* ── Glows ── */
+  --glow-accent: 0 0 24px rgba(0,212,255,0.2);
+  --glow-brand: 0 0 32px rgba(124,58,237,0.15);
+  /* ── Misc ── */
   --table-row-hover: rgba(255,255,255,0.03);
   --scrollbar-thumb: rgba(255,255,255,0.1);
 }
@@ -36,11 +63,38 @@
   --accent: #0891b2;
   --accent-dim: rgba(8,145,178,0.1);
   --accent-border: rgba(8,145,178,0.25);
+  --sev-critical: #e11d48;
+  --sev-critical-bg: rgba(225,29,72,0.08);
+  --sev-critical-border: rgba(225,29,72,0.25);
+  --sev-high: #d97706;
+  --sev-high-bg: rgba(217,119,6,0.08);
+  --sev-high-border: rgba(217,119,6,0.25);
+  --sev-medium: #ea580c;
+  --sev-medium-bg: rgba(234,88,12,0.08);
+  --sev-medium-border: rgba(234,88,12,0.25);
+  --sev-low: #2563eb;
+  --sev-low-bg: rgba(37,99,235,0.08);
+  --sev-low-border: rgba(37,99,235,0.25);
+  --sev-info: #7c3aed;
+  --sev-info-bg: rgba(124,58,237,0.08);
+  --sev-info-border: rgba(124,58,237,0.25);
+  --gradient-brand: linear-gradient(135deg, #0891b2 0%, #6d28d9 100%);
+  --gradient-brand-subtle: linear-gradient(135deg, rgba(8,145,178,0.12) 0%, rgba(109,40,217,0.12) 100%);
   --table-row-hover: rgba(0,0,0,0.02);
   --scrollbar-thumb: rgba(0,0,0,0.15);
 }
 
-/* ---- Base element overrides ---- */
+/* ── Dark-mode atmospheric background ── */
+/* !important so the gradient wins over any inline background on the body element */
+body {
+  background:
+    radial-gradient(ellipse at 15% 60%, rgba(0,212,255,0.04) 0%, transparent 55%),
+    radial-gradient(ellipse at 85% 15%, rgba(124,58,237,0.05) 0%, transparent 55%),
+    #0a0e1a !important;
+  color: var(--text-primary);
+}
+
+/* ── Base element overrides (light mode) ── */
 
 [data-theme="light"] body {
   background: var(--bg-page) !important;
@@ -57,7 +111,7 @@
   border-color: rgba(255,255,255,0.1) !important;
 }
 
-/* ---- CSS class overrides ---- */
+/* ── CSS class overrides (light mode) ── */
 
 [data-theme="light"] .card {
   background: var(--bg-card) !important;
@@ -97,7 +151,7 @@
   background: rgba(0,0,0,0.1) !important;
 }
 
-/* ---- Scrollbar ---- */
+/* ── Scrollbar ── */
 ::-webkit-scrollbar { width: 6px; }
 ::-webkit-scrollbar-track { background: transparent; }
 ::-webkit-scrollbar-thumb { background: var(--scrollbar-thumb); border-radius: 3px; }


### PR DESCRIPTION
## Summary
- **theme.css**: New CSS design tokens — richer severity colours (`--sev-critical #ff4757`, `--sev-high #ff9f43`, `--sev-medium #ff6b35`, `--sev-low #54a0ff`, `--sev-info #a29bfe`), brand gradient (`--gradient-brand`), glow variables, light-mode counterparts, and a radial-gradient atmospheric mesh applied to the dark-mode `body` via CSS
- **index.html**: All JS colour constants updated to match new palette — severity badges, donut chart, risk bar chart, table header columns, table row values; stat card icons now use gradient backgrounds with coloured glow box-shadows and a pulsing `iconGlow` CSS animation; header gets a subtle cyan glow shadow accent; sidebar logo border made more vibrant

## Test plan
- [ ] Visit dashboard at `http://localhost:8000` — colours are noticeably richer and more distinct
- [ ] Verify donut chart shows correct severity segment colours
- [ ] Verify severity badges in Recent Findings use the new palette
- [ ] Toggle light/dark mode — both work correctly (light mode severity tokens use accessible high-contrast variants)
- [ ] No JS console errors (favicon 404 is pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)