### PR TITLE
Fix ReDoS vulnerability in /patterns/test endpoint

### DIFF
--- a/backend/app/api/v1/secrets.py
+++ b/backend/app/api/v1/secrets.py
@@ -232,7 +232,7 @@ def _compile_and_match(pattern: str, sample_text: str) -> list:
 
 @router.post("/patterns/test", response_model=SecretPatternTestResult)
 async def test_pattern(payload: SecretPatternTest):
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     try:
         matches = await asyncio.wait_for(
             loop.run_in_executor(None, _compile_and_match, payload.pattern, payload.sample_text),

--- a/backend/app/api/v1/secrets.py
+++ b/backend/app/api/v1/secrets.py
@@ -1,3 +1,4 @@
+import asyncio
 import math
 import re
 import uuid
@@ -224,13 +225,26 @@ async def delete_pattern(pattern_id: uuid.UUID, db: AsyncSession = Depends(get_d
     await db.flush()
 
 
+def _compile_and_match(pattern: str, sample_text: str) -> list:
+    compiled = re.compile(pattern)
+    return compiled.findall(sample_text)
+
+
 @router.post("/patterns/test", response_model=SecretPatternTestResult)
 async def test_pattern(payload: SecretPatternTest):
+    loop = asyncio.get_event_loop()
     try:
-        compiled = re.compile(payload.pattern)
+        matches = await asyncio.wait_for(
+            loop.run_in_executor(None, _compile_and_match, payload.pattern, payload.sample_text),
+            timeout=5.0,
+        )
     except re.error as e:
         return SecretPatternTestResult(matches=[], match_count=0, valid=False, error=str(e))
+    except asyncio.TimeoutError:
+        return SecretPatternTestResult(
+            matches=[], match_count=0, valid=False,
+            error="Pattern evaluation timed out — the pattern may cause catastrophic backtracking",
+        )
 
-    matches = compiled.findall(payload.sample_text)
     str_matches = [m if isinstance(m, str) else str(m) for m in matches]
     return SecretPatternTestResult(matches=str_matches, match_count=len(str_matches), valid=True)

--- a/backend/app/schemas/secret_pattern.py
+++ b/backend/app/schemas/secret_pattern.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime
 from typing import List, Literal, Optional
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class SecretPatternBase(BaseModel):
@@ -34,8 +34,8 @@ class SecretPatternResponse(SecretPatternBase):
 
 
 class SecretPatternTest(BaseModel):
-    pattern: str
-    sample_text: str
+    pattern: str = Field(..., max_length=500)
+    sample_text: str = Field(..., max_length=100_000)
 
 
 class SecretPatternTestResult(BaseModel):


### PR DESCRIPTION
## Summary
- Addresses CodeQL alert `py/regex-injection` — the real threat is **ReDoS (catastrophic backtracking)**, not regex injection. `re.escape()` (the CodeQL default recommendation) would break this endpoint since it exists specifically to test user-provided patterns.
- Wrapped `re.compile` + `findall` in `asyncio.wait_for(run_in_executor(...), timeout=5.0)` — a backtracking pattern can no longer hang the event loop; returns a descriptive error instead
- Added `Field(max_length=500)` on `pattern` and `max_length=100_000` on `sample_text` in the Pydantic schema to bound worst-case input size

## Test plan
- [ ] All 28 existing secret pattern tests pass (`pytest tests/ -k secret`)
- [ ] Submit a known ReDoS pattern (e.g. `(a+)+`) with a long input string — should return timeout error within 5 seconds instead of hanging
- [ ] Submit a pattern longer than 500 chars — should return 422 Unprocessable Entity
- [ ] Normal valid patterns continue to work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)