### PR TITLE
feat: UI improvements — sidebar sections, profile widget, settings page, applications list view

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,14 @@ Snitch is an AppSec platform that aggregates security findings from Semgrep (SAS
 
 The sidebar is a shared JS component defined in `frontend/static/js/sidebar.js`. Each HTML page uses `<div id="sidebar-mount"></div>` followed by `<script src="/static/js/sidebar.js"></script>` — the script renders the full sidebar, auto-detects the active nav link, and defines `window.applyTheme()`. Do not duplicate sidebar HTML across pages; edit `sidebar.js` for any sidebar changes.
 
+The header user widget is a shared JS component defined in `frontend/static/js/header.js`. Each HTML page includes `<script src="/static/js/header.js"></script>` after the sidebar script and adds `id="header-user-slot"` to the right-side container inside `<header>`. The script injects a circular user avatar button with a dropdown (Profile link + disabled Logout placeholder) into that slot. Do not duplicate the widget HTML across pages; edit `header.js` for any user-menu changes.
+
+The sidebar nav is structured into three sections: **Overview** (Dashboard, Applications, Reports, Secrets), **Config** (Policies, Rules), **Admin** (Settings, Repositories). The Profile link has been removed from the sidebar — it is only accessible via the header user widget dropdown.
+
+The `/settings.html` page is the admin configuration page for platform integrations (GitHub token, Anthropic API key), scan defaults, and read-only system info. It stores token presence flags in `localStorage` only — raw secrets are never persisted client-side.
+
+The applications page (`/applications.html`) uses a sortable list/table view instead of a card grid. Default sort is risk score descending. Clicking any column header toggles ascending/descending sort.
+
 ## Commands
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@
 | 🔗 **GitHub Integration** | Sync code-scanning alerts from GitHub Security; auto-create branches & PRs |
 | 🚦 **Policy Engine** | Define pass/fail gates by severity, scan type, and rule — evaluated on every scan |
 | 🌐 **REST API** | Full OpenAPI/Swagger docs at `/docs` |
-| 🎨 **Consistent UI** | Shared sidebar component (`sidebar.js`) and design tokens in `theme.css` — single source of truth for navigation and styles |
+| 🎨 **Consistent UI** | Shared sidebar (`sidebar.js`) and header (`header.js`) components with design tokens in `theme.css` — single source of truth for navigation and styles |
+| ⚙️ **Settings Page** | Admin configuration page for platform integrations (GitHub, Anthropic), scan defaults, and system status |
+| 📋 **Applications List View** | Sortable table view for the applications portfolio — click any column header to re-sort |
 
 ---
 

--- a/frontend/app-detail.html
+++ b/frontend/app-detail.html
@@ -38,6 +38,7 @@
   <!-- Sidebar -->
   <div id="sidebar-mount"></div>
   <script src="/static/js/sidebar.js"></script>
+  <script src="/static/js/header.js"></script>
 
   <!-- Main -->
   <div id="main-content" style="margin-left:260px;min-height:100vh;">
@@ -52,7 +53,7 @@
         </div>
         <h1 id="page-title" style="font-size:22px;font-weight:700;color:#f1f5f9;margin:0;">Application Detail</h1>
       </div>
-      <div style="display:flex;gap:10px;">
+      <div id="header-user-slot" style="display:flex;gap:10px;align-items:center;">
         <button class="btn-secondary" onclick="openRemediationModal()">
           <i data-lucide="sparkles" style="width:16px;height:16px;color:#6366f1;"></i> Plan Remediation
         </button>

--- a/frontend/applications.html
+++ b/frontend/applications.html
@@ -7,7 +7,6 @@
   <script>(function(){document.documentElement.setAttribute('data-theme',localStorage.getItem('theme')||'dark');})();</script>
   <style>/* Inter font fallback */ body { font-family: "Inter", system-ui, -apple-system, sans-serif; }</style>
   <link rel="stylesheet" href="/static/css/theme.css">
-  <script src="/static/js/chart.min.js"></script>
   <script src="/static/js/lucide.min.js"></script>
   <style>
     * { box-sizing: border-box; }
@@ -16,11 +15,19 @@
     @keyframes pulse { 0%,100%{opacity:1} 50%{opacity:0.5} }
     @keyframes fadeInUp { from{transform:translateY(20px);opacity:0} to{transform:translateY(0);opacity:1} }
     @keyframes spin { to{transform:rotate(360deg)} }
-    @keyframes glow { 0%,100%{box-shadow:0 0 20px rgba(0,212,255,0.3)} 50%{box-shadow:0 0 40px rgba(0,212,255,0.6)} }
-    .card-hover:hover { border-color:rgba(0,212,255,0.3) !important; transform:translateY(-2px); transition:all 0.3s; }
     .card { background:rgba(13,17,23,0.8);border:1px solid rgba(255,255,255,0.08);border-radius:16px;backdrop-filter:blur(20px); }
     .dark-select option { background:#0d1117; }
     .modal-backdrop { position:fixed;inset:0;background:rgba(0,0,0,0.7);backdrop-filter:blur(8px);z-index:200;display:flex;align-items:center;justify-content:center; }
+    .app-row { cursor:pointer;transition:background 0.15s; }
+    .app-row:hover { background:rgba(255,255,255,0.03) !important; }
+    .sort-btn { background:none;border:none;display:inline-flex;align-items:center;gap:4px;cursor:pointer;font-size:12px;font-weight:600;color:#64748b;text-transform:uppercase;letter-spacing:0.5px;padding:0;white-space:nowrap;transition:color 0.15s; }
+    .sort-btn:hover { color:#94a3b8; }
+    .sort-btn.active { color:#00d4ff; }
+    .pill { display:inline-flex;align-items:center;justify-content:center;min-width:28px;padding:2px 7px;border-radius:6px;font-size:11px;font-weight:700; }
+    .pill-c { background:rgba(239,68,68,0.12);color:#ef4444;border:1px solid rgba(239,68,68,0.2); }
+    .pill-h { background:rgba(245,158,11,0.12);color:#f59e0b;border:1px solid rgba(245,158,11,0.2); }
+    .pill-m { background:rgba(249,115,22,0.12);color:#f97316;border:1px solid rgba(249,115,22,0.2); }
+    .pill-l { background:rgba(59,130,246,0.12);color:#3b82f6;border:1px solid rgba(59,130,246,0.2); }
   </style>
 </head>
 <body style="font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg-page,#0a0e1a);color:var(--text-primary,#f1f5f9);margin:0;padding:0;min-height:100vh;">
@@ -28,6 +35,7 @@
   <!-- Sidebar -->
   <div id="sidebar-mount"></div>
   <script src="/static/js/sidebar.js"></script>
+  <script src="/static/js/header.js"></script>
 
   <!-- Main -->
   <div id="main-content" style="margin-left:260px;min-height:100vh;">
@@ -36,7 +44,7 @@
         <h1 style="font-size:22px;font-weight:700;color:#f1f5f9;margin:0;">Applications</h1>
         <p style="font-size:13px;color:#475569;margin:2px 0 0;">Manage and monitor your application portfolio</p>
       </div>
-      <div style="display:flex;align-items:center;gap:12px;">
+      <div id="header-user-slot" style="display:flex;align-items:center;gap:12px;">
         <!-- Search -->
         <div style="position:relative;">
           <i data-lucide="search" style="width:16px;height:16px;color:#475569;position:absolute;left:10px;top:50%;transform:translateY(-50%);pointer-events:none;"></i>
@@ -61,12 +69,88 @@
     </header>
 
     <main style="padding:32px;">
-      <div id="apps-count" style="font-size:13px;color:#475569;margin-bottom:20px;">Loading applications...</div>
-      <div id="apps-grid" style="display:grid;grid-template-columns:repeat(3,1fr);gap:20px;">
-        <!-- Skeletons -->
-        <div class="card" style="padding:24px;animation:pulse 1.5s infinite;"><div style="height:20px;background:rgba(255,255,255,0.05);border-radius:6px;margin-bottom:16px;width:70%;"></div><div style="height:120px;background:rgba(255,255,255,0.03);border-radius:50%;width:120px;margin:0 auto 16px;"></div><div style="height:14px;background:rgba(255,255,255,0.05);border-radius:6px;margin-bottom:8px;width:80%;margin:0 auto 8px;"></div><div style="height:14px;background:rgba(255,255,255,0.05);border-radius:6px;width:60%;margin:0 auto;"></div></div>
-        <div class="card" style="padding:24px;animation:pulse 1.5s infinite;"><div style="height:20px;background:rgba(255,255,255,0.05);border-radius:6px;margin-bottom:16px;width:70%;"></div><div style="height:120px;background:rgba(255,255,255,0.03);border-radius:50%;width:120px;margin:0 auto 16px;"></div><div style="height:14px;background:rgba(255,255,255,0.05);border-radius:6px;margin-bottom:8px;width:80%;margin:0 auto 8px;"></div><div style="height:14px;background:rgba(255,255,255,0.05);border-radius:6px;width:60%;margin:0 auto;"></div></div>
-        <div class="card" style="padding:24px;animation:pulse 1.5s infinite;"><div style="height:20px;background:rgba(255,255,255,0.05);border-radius:6px;margin-bottom:16px;width:70%;"></div><div style="height:120px;background:rgba(255,255,255,0.03);border-radius:50%;width:120px;margin:0 auto 16px;"></div><div style="height:14px;background:rgba(255,255,255,0.05);border-radius:6px;margin-bottom:8px;width:80%;margin:0 auto 8px;"></div><div style="height:14px;background:rgba(255,255,255,0.05);border-radius:6px;width:60%;margin:0 auto;"></div></div>
+      <div id="apps-count" style="font-size:13px;color:#475569;margin-bottom:16px;">Loading applications...</div>
+
+      <!-- Table -->
+      <div class="card" style="overflow:hidden;">
+        <div style="overflow-x:auto;">
+          <table style="width:100%;border-collapse:collapse;">
+            <thead>
+              <tr style="border-bottom:1px solid rgba(255,255,255,0.08);">
+                <th style="padding:12px 16px;text-align:left;">
+                  <button class="sort-btn" id="sort-name" onclick="setSort('name')">
+                    Name <i data-lucide="chevrons-up-down" style="width:14px;height:14px;"></i>
+                  </button>
+                </th>
+                <th style="padding:12px 16px;text-align:left;">
+                  <button class="sort-btn" id="sort-team_name" onclick="setSort('team_name')">
+                    Team <i data-lucide="chevrons-up-down" style="width:14px;height:14px;"></i>
+                  </button>
+                </th>
+                <th style="padding:12px 16px;text-align:left;">
+                  <button class="sort-btn active" id="sort-risk_score" onclick="setSort('risk_score')">
+                    Risk Score <i data-lucide="chevron-down" style="width:14px;height:14px;"></i>
+                  </button>
+                </th>
+                <th style="padding:12px 16px;text-align:center;">
+                  <button class="sort-btn" id="sort-critical_count" onclick="setSort('critical_count')" title="Critical findings">
+                    C <i data-lucide="chevrons-up-down" style="width:14px;height:14px;"></i>
+                  </button>
+                </th>
+                <th style="padding:12px 16px;text-align:center;">
+                  <button class="sort-btn" id="sort-high_count" onclick="setSort('high_count')" title="High findings">
+                    H <i data-lucide="chevrons-up-down" style="width:14px;height:14px;"></i>
+                  </button>
+                </th>
+                <th style="padding:12px 16px;text-align:center;">
+                  <button class="sort-btn" id="sort-medium_count" onclick="setSort('medium_count')" title="Medium findings">
+                    M <i data-lucide="chevrons-up-down" style="width:14px;height:14px;"></i>
+                  </button>
+                </th>
+                <th style="padding:12px 16px;text-align:center;">
+                  <button class="sort-btn" id="sort-low_count" onclick="setSort('low_count')" title="Low findings">
+                    L <i data-lucide="chevrons-up-down" style="width:14px;height:14px;"></i>
+                  </button>
+                </th>
+                <th style="padding:12px 16px;text-align:left;">
+                  <button class="sort-btn" id="sort-language" onclick="setSort('language')">
+                    Language <i data-lucide="chevrons-up-down" style="width:14px;height:14px;"></i>
+                  </button>
+                </th>
+                <th style="padding:12px 16px;text-align:left;">
+                  <button class="sort-btn" id="sort-last_scan_at" onclick="setSort('last_scan_at')">
+                    Last Scan <i data-lucide="chevrons-up-down" style="width:14px;height:14px;"></i>
+                  </button>
+                </th>
+                <th style="padding:12px 16px;text-align:center;font-size:12px;font-weight:600;color:#64748b;text-transform:uppercase;letter-spacing:0.5px;">Actions</th>
+              </tr>
+            </thead>
+            <tbody id="apps-tbody">
+              <!-- Skeleton rows -->
+              <tr><td colspan="10" style="padding:0;">
+                <div style="padding:14px 16px;animation:pulse 1.5s infinite;border-bottom:1px solid rgba(255,255,255,0.04);display:flex;gap:16px;align-items:center;">
+                  <div style="height:14px;background:rgba(255,255,255,0.06);border-radius:4px;flex:1;max-width:160px;"></div>
+                  <div style="height:12px;background:rgba(255,255,255,0.04);border-radius:4px;width:80px;"></div>
+                  <div style="height:22px;background:rgba(255,255,255,0.06);border-radius:6px;width:90px;"></div>
+                </div>
+              </td></tr>
+              <tr><td colspan="10" style="padding:0;">
+                <div style="padding:14px 16px;animation:pulse 1.5s infinite;border-bottom:1px solid rgba(255,255,255,0.04);display:flex;gap:16px;align-items:center;">
+                  <div style="height:14px;background:rgba(255,255,255,0.06);border-radius:4px;flex:1;max-width:200px;"></div>
+                  <div style="height:12px;background:rgba(255,255,255,0.04);border-radius:4px;width:100px;"></div>
+                  <div style="height:22px;background:rgba(255,255,255,0.06);border-radius:6px;width:80px;"></div>
+                </div>
+              </td></tr>
+              <tr><td colspan="10" style="padding:0;">
+                <div style="padding:14px 16px;animation:pulse 1.5s infinite;display:flex;gap:16px;align-items:center;">
+                  <div style="height:14px;background:rgba(255,255,255,0.06);border-radius:4px;flex:1;max-width:140px;"></div>
+                  <div style="height:12px;background:rgba(255,255,255,0.04);border-radius:4px;width:90px;"></div>
+                  <div style="height:22px;background:rgba(255,255,255,0.06);border-radius:6px;width:100px;"></div>
+                </div>
+              </td></tr>
+            </tbody>
+          </table>
+        </div>
       </div>
     </main>
   </div>
@@ -127,6 +211,8 @@
 
 <script>
 let allApps = [];
+let sortColumn = 'risk_score';
+let sortDir = 'desc';
 
 // ── Utilities ──────────────────────────────────────────────────────────────────
 function getRiskColor(score) {
@@ -169,82 +255,101 @@ function showToast(message, type='success') {
   setTimeout(() => { toast.style.animation='slideOutRight 0.3s ease forwards'; setTimeout(()=>toast.remove(),300); }, 3500);
 }
 
-// ── Gauge SVG ──────────────────────────────────────────────────────────────────
-function gaugeCircle(score) {
-  const r = 45, cx = 60, cy = 60;
-  const circ = 2 * Math.PI * r;
-  const offset = circ - (score / 100) * circ;
-  const color = getRiskColor(score);
-  const risk = getRiskLevel(score);
-  return `
-    <svg viewBox="0 0 120 120" width="120" height="120">
-      <circle cx="${cx}" cy="${cy}" r="${r}" fill="none" stroke="rgba(255,255,255,0.08)" stroke-width="8"/>
-      <circle cx="${cx}" cy="${cy}" r="${r}" fill="none"
-        stroke="${color}" stroke-width="8" stroke-linecap="round"
-        stroke-dasharray="${circ}" stroke-dashoffset="${offset}"
-        transform="rotate(-90 ${cx} ${cy})" style="transition:stroke-dashoffset 1s ease;"/>
-      <text x="${cx}" y="${cy-5}" text-anchor="middle" fill="${color}" font-size="22" font-weight="800" font-family="Inter,sans-serif">${score}</text>
-      <text x="${cx}" y="${cy+14}" text-anchor="middle" fill="rgba(255,255,255,0.3)" font-size="10" font-family="Inter,sans-serif">/ 100</text>
-    </svg>
-  `;
+// ── Sorting ────────────────────────────────────────────────────────────────────
+function setSort(col) {
+  if (sortColumn === col) {
+    sortDir = sortDir === 'desc' ? 'asc' : 'desc';
+  } else {
+    sortColumn = col;
+    sortDir = 'desc';
+  }
+  updateSortHeaders();
+  applyFilters();
 }
 
-// ── App Card ───────────────────────────────────────────────────────────────────
-function appCard(app, idx) {
+function updateSortHeaders() {
+  const cols = ['name','team_name','risk_score','critical_count','high_count','medium_count','low_count','language','last_scan_at'];
+  cols.forEach(col => {
+    const btn = document.getElementById('sort-' + col);
+    if (!btn) return;
+    const isActive = col === sortColumn;
+    btn.classList.toggle('active', isActive);
+    const icon = btn.querySelector('i[data-lucide]');
+    if (icon) {
+      if (isActive) {
+        icon.setAttribute('data-lucide', sortDir === 'desc' ? 'chevron-down' : 'chevron-up');
+      } else {
+        icon.setAttribute('data-lucide', 'chevrons-up-down');
+      }
+    }
+  });
+  lucide.createIcons();
+}
+
+function sortApps(apps) {
+  return [...apps].sort((a, b) => {
+    let va = a[sortColumn] ?? (typeof a[sortColumn] === 'number' ? -1 : '');
+    let vb = b[sortColumn] ?? (typeof b[sortColumn] === 'number' ? -1 : '');
+
+    // Map API field names to actual finding count fields
+    if (sortColumn === 'critical_count') { va = (a.findings_summary?.critical ?? a.critical_count ?? 0); vb = (b.findings_summary?.critical ?? b.critical_count ?? 0); }
+    if (sortColumn === 'high_count')     { va = (a.findings_summary?.high ?? a.high_count ?? 0);         vb = (b.findings_summary?.high ?? b.high_count ?? 0); }
+    if (sortColumn === 'medium_count')   { va = (a.findings_summary?.medium ?? a.medium_count ?? 0);     vb = (b.findings_summary?.medium ?? b.medium_count ?? 0); }
+    if (sortColumn === 'low_count')      { va = (a.findings_summary?.low ?? a.low_count ?? 0);           vb = (b.findings_summary?.low ?? b.low_count ?? 0); }
+    if (sortColumn === 'last_scan_at')   { va = va ? new Date(va).getTime() : 0; vb = vb ? new Date(vb).getTime() : 0; }
+
+    if (typeof va === 'string') va = va.toLowerCase();
+    if (typeof vb === 'string') vb = vb.toLowerCase();
+
+    if (va < vb) return sortDir === 'asc' ? -1 : 1;
+    if (va > vb) return sortDir === 'asc' ? 1 : -1;
+    return 0;
+  });
+}
+
+// ── App Row ────────────────────────────────────────────────────────────────────
+function appRow(app) {
   const score = app.risk_score || 0;
-  const risk = getRiskLevel(score);
-  const fs = app.findings_summary || {};
+  const risk  = getRiskLevel(score);
+  const fs    = app.findings_summary || {};
   const c = fs.critical ?? app.critical_count ?? 0;
-  const h = fs.high ?? app.high_count ?? 0;
-  const m = fs.medium ?? app.medium_count ?? 0;
-  const l = fs.low ?? app.low_count ?? 0;
+  const h = fs.high     ?? app.high_count     ?? 0;
+  const m = fs.medium   ?? app.medium_count   ?? 0;
+  const l = fs.low      ?? app.low_count      ?? 0;
   const langColors = { Python:'#3b82f6', JavaScript:'#f59e0b', TypeScript:'#6366f1', Go:'#00d4ff', Java:'#f97316', Kotlin:'#a78bfa', Ruby:'#ef4444', PHP:'#8b5cf6', 'C#':'#10b981', 'C++':'#94a3b8', Rust:'#f97316' };
   const langColor = langColors[app.language] || '#475569';
 
   return `
-    <div class="card card-hover" style="padding:24px;cursor:pointer;animation:fadeInUp 0.4s ease both;animation-delay:${idx*0.05}s;display:flex;flex-direction:column;" onclick="location.href='/app-detail.html?id=${app.id}'">
-      <!-- Header -->
-      <div style="display:flex;align-items:flex-start;justify-content:space-between;margin-bottom:16px;">
-        <div style="flex:1;min-width:0;">
-          <div style="font-size:15px;font-weight:700;color:#f1f5f9;margin-bottom:4px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${app.name||'—'}</div>
-          <span style="background:rgba(0,212,255,0.1);color:#00d4ff;border:1px solid rgba(0,212,255,0.2);padding:2px 8px;border-radius:6px;font-size:11px;font-weight:500;">${app.team_name||'No team'}</span>
-        </div>
-      </div>
-
-      <!-- Gauge -->
-      <div style="display:flex;justify-content:center;margin-bottom:12px;">
-        ${gaugeCircle(score)}
-      </div>
-
-      <!-- Risk Badge -->
-      <div style="text-align:center;margin-bottom:16px;">
-        <span style="background:${risk.bg};color:${risk.color};border:1px solid ${risk.color}44;padding:4px 14px;border-radius:8px;font-size:12px;font-weight:700;">${risk.label} Risk</span>
-      </div>
-
-      <!-- Finding Pills -->
-      <div style="display:flex;justify-content:center;gap:8px;margin-bottom:16px;flex-wrap:wrap;">
-        <span style="background:rgba(239,68,68,0.12);color:#ef4444;border:1px solid rgba(239,68,68,0.2);padding:3px 8px;border-radius:6px;font-size:11px;font-weight:600;">${c} C</span>
-        <span style="background:rgba(245,158,11,0.12);color:#f59e0b;border:1px solid rgba(245,158,11,0.2);padding:3px 8px;border-radius:6px;font-size:11px;font-weight:600;">${h} H</span>
-        <span style="background:rgba(249,115,22,0.12);color:#f97316;border:1px solid rgba(249,115,22,0.2);padding:3px 8px;border-radius:6px;font-size:11px;font-weight:600;">${m} M</span>
-        <span style="background:rgba(59,130,246,0.12);color:#3b82f6;border:1px solid rgba(59,130,246,0.2);padding:3px 8px;border-radius:6px;font-size:11px;font-weight:600;">${l} L</span>
-      </div>
-
-      <!-- Footer -->
-      <div style="display:flex;align-items:center;justify-content:space-between;margin-top:auto;padding-top:12px;border-top:1px solid rgba(255,255,255,0.06);">
-        <span style="background:${langColor}22;color:${langColor};border:1px solid ${langColor}33;padding:2px 8px;border-radius:6px;font-size:11px;font-weight:500;">${app.language||'Unknown'}</span>
-        <span style="font-size:11px;color:#475569;">Scanned ${timeAgo(app.last_scan_at)}</span>
-      </div>
-
-      <!-- Action Buttons -->
-      <div style="display:flex;gap:8px;margin-top:12px;" onclick="event.stopPropagation()">
-        <button onclick="location.href='/app-detail.html?id=${app.id}'" class="btn-secondary" style="flex:1;padding:8px 12px;font-size:13px;">
-          <i data-lucide="eye" style="width:14px;height:14px;"></i> View Details
+    <tr class="app-row" onclick="location.href='/app-detail.html?id=${app.id}'" style="border-bottom:1px solid rgba(255,255,255,0.04);">
+      <td style="padding:14px 16px;">
+        <div style="font-size:14px;font-weight:600;color:#f1f5f9;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:200px;">${app.name || '—'}</div>
+        ${app.github_org ? `<div style="font-size:11px;color:#475569;margin-top:1px;">${app.github_org}/${app.github_repo||''}</div>` : ''}
+      </td>
+      <td style="padding:14px 16px;">
+        <span style="background:rgba(0,212,255,0.08);color:#00d4ff;border:1px solid rgba(0,212,255,0.15);padding:2px 8px;border-radius:6px;font-size:11px;font-weight:500;white-space:nowrap;">${app.team_name || '—'}</span>
+      </td>
+      <td style="padding:14px 16px;white-space:nowrap;">
+        <span style="background:${risk.bg};color:${risk.color};border:1px solid ${risk.color}33;padding:3px 10px;border-radius:8px;font-size:12px;font-weight:700;">
+          ${score} &nbsp;${risk.label}
+        </span>
+      </td>
+      <td style="padding:14px 8px;text-align:center;"><span class="pill pill-c">${c}</span></td>
+      <td style="padding:14px 8px;text-align:center;"><span class="pill pill-h">${h}</span></td>
+      <td style="padding:14px 8px;text-align:center;"><span class="pill pill-m">${m}</span></td>
+      <td style="padding:14px 8px;text-align:center;"><span class="pill pill-l">${l}</span></td>
+      <td style="padding:14px 16px;">
+        ${app.language ? `<span style="background:${langColor}22;color:${langColor};border:1px solid ${langColor}33;padding:2px 8px;border-radius:6px;font-size:11px;font-weight:500;">${app.language}</span>` : '<span style="color:#475569;font-size:12px;">—</span>'}
+      </td>
+      <td style="padding:14px 16px;font-size:12px;color:#475569;white-space:nowrap;">${timeAgo(app.last_scan_at)}</td>
+      <td style="padding:14px 16px;text-align:center;white-space:nowrap;" onclick="event.stopPropagation()">
+        <button onclick="location.href='/app-detail.html?id=${app.id}'" class="btn-secondary" style="padding:6px 10px;font-size:12px;margin-right:4px;" title="View details">
+          <i data-lucide="eye" style="width:14px;height:14px;"></i>
         </button>
-        <button onclick="runScan(event,'${app.id}','${app.name||'app'}')" id="scan-btn-${app.id}" class="btn-secondary" style="padding:8px 12px;font-size:13px;">
+        <button onclick="runScan(event,'${app.id}','${app.name||'app'}')" id="scan-btn-${app.id}" class="btn-secondary" style="padding:6px 10px;font-size:12px;" title="Run scan">
           <i data-lucide="play" style="width:14px;height:14px;color:#00d4ff;"></i>
         </button>
-      </div>
-    </div>
+      </td>
+    </tr>
   `;
 }
 
@@ -270,46 +375,45 @@ async function runScan(e, id, name) {
 
 // ── Filters ────────────────────────────────────────────────────────────────────
 function applyFilters() {
-  const search = document.getElementById('search-input').value.toLowerCase();
-  const team = document.getElementById('team-filter').value;
+  const search    = document.getElementById('search-input').value.toLowerCase();
+  const team      = document.getElementById('team-filter').value;
   const riskFilter = document.getElementById('risk-filter').value;
 
   const filtered = allApps.filter(app => {
     const nameMatch = !search || (app.name||'').toLowerCase().includes(search);
-    const teamMatch = !team || app.team_name === team;
+    const teamMatch = !team   || app.team_name === team;
     const riskMatch = !riskFilter || getRiskLevel(app.risk_score||0).label.toLowerCase() === riskFilter;
     return nameMatch && teamMatch && riskMatch;
   });
 
-  renderGrid(filtered);
+  renderList(filtered);
 }
 
 function populateTeamFilter(apps) {
   const teams = [...new Set(apps.map(a => a.team_name).filter(Boolean))].sort();
-  const sel = document.getElementById('team-filter');
-  const current = sel.value;
-  sel.innerHTML = '<option value="">All Teams</option>' + teams.map(t => `<option value="${t}" ${t===current?'selected':''}>${t}</option>`).join('');
+  const sel   = document.getElementById('team-filter');
+  const cur   = sel.value;
+  sel.innerHTML = '<option value="">All Teams</option>' + teams.map(t => `<option value="${t}" ${t===cur?'selected':''}>${t}</option>`).join('');
 }
 
-function renderGrid(apps) {
-  const grid = document.getElementById('apps-grid');
+function renderList(apps) {
+  const tbody = document.getElementById('apps-tbody');
   const count = document.getElementById('apps-count');
   count.textContent = `Showing ${apps.length} of ${allApps.length} application${allApps.length !== 1 ? 's' : ''}`;
 
   if (apps.length === 0) {
-    grid.innerHTML = `
-      <div style="grid-column:1/-1;text-align:center;padding:80px 20px;">
+    tbody.innerHTML = `
+      <tr><td colspan="10" style="text-align:center;padding:80px 20px;">
         <i data-lucide="inbox" style="width:48px;height:48px;color:#475569;margin:0 auto 16px;display:block;"></i>
         <div style="font-size:18px;font-weight:600;color:#f1f5f9;margin-bottom:8px;">No applications found</div>
         <p style="color:#475569;margin-bottom:24px;">Try adjusting your filters or add your first application.</p>
         <button class="btn-primary" onclick="openAddModal()"><i data-lucide="plus" style="width:16px;height:16px;"></i> Add your first application</button>
-      </div>
-    `;
+      </td></tr>`;
     lucide.createIcons();
     return;
   }
 
-  grid.innerHTML = apps.map((app, i) => appCard(app, i)).join('');
+  tbody.innerHTML = sortApps(apps).map(appRow).join('');
   lucide.createIcons();
 }
 
@@ -335,11 +439,11 @@ async function submitAddApp(e) {
   btn.innerHTML = '<div style="animation:spin 1s linear infinite;display:inline-block;width:16px;height:16px;border:2px solid rgba(255,255,255,0.3);border-top-color:white;border-radius:50%;"></div> Adding...';
 
   const payload = {
-    name: document.getElementById('field-name').value.trim(),
-    github_org: document.getElementById('field-github-org').value.trim() || undefined,
+    name:        document.getElementById('field-name').value.trim(),
+    github_org:  document.getElementById('field-github-org').value.trim()  || undefined,
     github_repo: document.getElementById('field-github-repo').value.trim() || undefined,
-    team_name: document.getElementById('field-team').value.trim() || undefined,
-    language: document.getElementById('field-language').value || undefined,
+    team_name:   document.getElementById('field-team').value.trim()        || undefined,
+    language:    document.getElementById('field-language').value           || undefined,
     description: document.getElementById('field-description').value.trim() || undefined,
   };
 
@@ -376,16 +480,14 @@ async function loadApplications() {
     applyFilters();
   } catch(e) {
     allApps = [];
-    const _errorGrid = document.getElementById('apps-grid');
-    const _errContainer = document.createElement('div');
-    _errContainer.style.cssText = 'grid-column:1/-1;text-align:center;padding:80px 20px;';
-    _errContainer.innerHTML = '<i data-lucide="wifi-off" style="width:48px;height:48px;color:#ef4444;margin:0 auto 16px;display:block;opacity:0.5;"></i><div style="font-size:18px;font-weight:600;color:#f1f5f9;margin-bottom:8px;">Failed to load applications</div><button class="btn-secondary" onclick="loadApplications()"><i data-lucide="refresh-cw" style="width:16px;height:16px;"></i> Retry</button>';
-    const _errMsg = document.createElement('p');
-    _errMsg.style.cssText = 'color:#475569;margin-bottom:24px;';
-    _errMsg.textContent = e.message || 'An error occurred';
-    _errContainer.insertBefore(_errMsg, _errContainer.lastElementChild);
-    _errorGrid.innerHTML = '';
-    _errorGrid.appendChild(_errContainer);
+    const tbody = document.getElementById('apps-tbody');
+    tbody.innerHTML = `
+      <tr><td colspan="10" style="text-align:center;padding:80px 20px;">
+        <i data-lucide="wifi-off" style="width:48px;height:48px;color:#ef4444;margin:0 auto 16px;display:block;opacity:0.5;"></i>
+        <div style="font-size:18px;font-weight:600;color:#f1f5f9;margin-bottom:8px;">Failed to load applications</div>
+        <p style="color:#475569;margin-bottom:24px;">${e.message || 'An error occurred'}</p>
+        <button class="btn-secondary" onclick="loadApplications()"><i data-lucide="refresh-cw" style="width:16px;height:16px;"></i> Retry</button>
+      </td></tr>`;
     lucide.createIcons();
     showToast('Failed to load applications', 'error');
   }
@@ -398,6 +500,7 @@ document.addEventListener('keydown', e => {
 
 document.addEventListener('DOMContentLoaded', () => {
   applyTheme(localStorage.getItem('theme')||'dark');
+  updateSortHeaders();
   lucide.createIcons();
   loadApplications();
 });

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -28,6 +28,7 @@
   <!-- Sidebar -->
   <div id="sidebar-mount"></div>
   <script src="/static/js/sidebar.js"></script>
+  <script src="/static/js/header.js"></script>
 
   <!-- Main -->
   <div id="main-content" style="margin-left:260px;min-height:100vh;">
@@ -36,6 +37,7 @@
         <h1 style="font-size:22px;font-weight:700;color:#f1f5f9;margin:0;">Security Overview</h1>
         <p style="font-size:13px;color:#475569;margin:2px 0 0;">Real-time application security monitoring</p>
       </div>
+      <div id="header-user-slot" style="display:flex;align-items:center;gap:8px;"></div>
     </header>
 
     <main style="padding:32px;">

--- a/frontend/policies.html
+++ b/frontend/policies.html
@@ -50,6 +50,7 @@
   <!-- Sidebar -->
   <div id="sidebar-mount"></div>
   <script src="/static/js/sidebar.js"></script>
+  <script src="/static/js/header.js"></script>
 
   <!-- Main -->
   <div id="main-content" style="margin-left:260px;min-height:100vh;">
@@ -58,7 +59,7 @@
         <h1 style="font-size:22px;font-weight:700;color:#f1f5f9;margin:0;">Security Policies</h1>
         <p style="font-size:13px;color:#475569;margin:2px 0 0;">Define scan rules, severity thresholds, and enforcement actions</p>
       </div>
-      <div style="display:flex;gap:10px;align-items:center;">
+      <div id="header-user-slot" style="display:flex;gap:10px;align-items:center;">
         <button class="btn-secondary" onclick="seedDefaultPolicies()" id="seed-btn" title="Create default CIS L1-aligned policies">
           <i data-lucide="database" style="width:14px;height:14px;display:inline-block;vertical-align:middle;margin-right:4px;"></i> Seed Defaults
         </button>

--- a/frontend/profile.html
+++ b/frontend/profile.html
@@ -48,6 +48,7 @@
   <!-- Sidebar -->
   <div id="sidebar-mount"></div>
   <script src="/static/js/sidebar.js"></script>
+  <script src="/static/js/header.js"></script>
 
   <!-- Main -->
   <div id="main-content" style="margin-left:260px;min-height:100vh;">
@@ -56,6 +57,7 @@
         <h1 style="font-size:22px;font-weight:700;color:#f1f5f9;margin:0;">Profile &amp; Preferences</h1>
         <p style="font-size:13px;color:#475569;margin:2px 0 0;">Manage your account settings and preferences</p>
       </div>
+      <div id="header-user-slot" style="display:flex;align-items:center;gap:8px;"></div>
     </header>
 
     <main style="padding:32px;max-width:900px;">

--- a/frontend/reports.html
+++ b/frontend/reports.html
@@ -30,6 +30,7 @@
   <!-- Sidebar -->
   <div id="sidebar-mount"></div>
   <script src="/static/js/sidebar.js"></script>
+  <script src="/static/js/header.js"></script>
 
   <!-- Main -->
   <div id="main-content" style="margin-left:260px;min-height:100vh;">
@@ -38,12 +39,14 @@
         <h1 style="font-size:22px;font-weight:700;color:#f1f5f9;margin:0;">Security Reports</h1>
         <p style="font-size:13px;color:#475569;margin:2px 0 0;">Analytics and insights across your application portfolio</p>
       </div>
-      <!-- Date Range Buttons -->
-      <div style="display:flex;gap:4px;background:rgba(0,0,0,0.3);padding:4px;border-radius:10px;border:1px solid rgba(255,255,255,0.06);">
-        <button class="range-btn" id="range-7" onclick="setRange(7)">7d</button>
-        <button class="range-btn" id="range-30" onclick="setRange(30)">30d</button>
-        <button class="range-btn" id="range-60" onclick="setRange(60)">60d</button>
-        <button class="range-btn active" id="range-90" onclick="setRange(90)">90d</button>
+      <!-- Date Range Buttons + user widget -->
+      <div id="header-user-slot" style="display:flex;align-items:center;gap:12px;">
+        <div style="display:flex;gap:4px;background:rgba(0,0,0,0.3);padding:4px;border-radius:10px;border:1px solid rgba(255,255,255,0.06);">
+          <button class="range-btn" id="range-7" onclick="setRange(7)">7d</button>
+          <button class="range-btn" id="range-30" onclick="setRange(30)">30d</button>
+          <button class="range-btn" id="range-60" onclick="setRange(60)">60d</button>
+          <button class="range-btn active" id="range-90" onclick="setRange(90)">90d</button>
+        </div>
       </div>
     </header>
 

--- a/frontend/repositories.html
+++ b/frontend/repositories.html
@@ -23,20 +23,23 @@
   <!-- Sidebar -->
   <div id="sidebar-mount"></div>
   <script src="/static/js/sidebar.js"></script>
+  <script src="/static/js/header.js"></script>
 
   <!-- Main content -->
-  <div id="main-content" style="margin-left:260px;padding:32px;min-height:100vh;">
-
-    <!-- Header -->
-    <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:28px;">
+  <div id="main-content" style="margin-left:260px;min-height:100vh;">
+    <header style="background:rgba(8,12,24,0.9);backdrop-filter:blur(20px);border-bottom:1px solid rgba(255,255,255,0.08);padding:16px 32px;display:flex;align-items:center;justify-content:space-between;position:sticky;top:0;z-index:50;">
       <div>
-        <h1 style="font-size:22px;font-weight:700;color:#f1f5f9;margin:0 0 4px;">Repositories</h1>
-        <p style="color:#64748b;font-size:14px;margin:0;">Discover and track GitHub repositories for security scanning</p>
+        <h1 style="font-size:22px;font-weight:700;color:#f1f5f9;margin:0;">Repositories</h1>
+        <p style="font-size:13px;color:#475569;margin:2px 0 0;">Discover and track GitHub repositories for security scanning</p>
       </div>
-      <button class="btn-primary" onclick="loadRepos()">
-        <i data-lucide="refresh-cw" style="width:16px;height:16px;" id="refresh-icon"></i> Refresh
-      </button>
-    </div>
+      <div id="header-user-slot" style="display:flex;align-items:center;gap:12px;">
+        <button class="btn-primary" onclick="loadRepos()">
+          <i data-lucide="refresh-cw" style="width:16px;height:16px;" id="refresh-icon"></i> Refresh
+        </button>
+      </div>
+    </header>
+
+    <div style="padding:32px;">
 
     <!-- Filters -->
     <div class="card" style="padding:16px 20px;margin-bottom:20px;display:flex;align-items:center;gap:12px;flex-wrap:wrap;">
@@ -76,6 +79,7 @@
       <div style="width:32px;height:32px;border:3px solid rgba(0,212,255,0.2);border-top-color:#00d4ff;border-radius:50%;animation:spin 0.8s linear infinite;margin:0 auto 16px;"></div>
       <div style="color:#64748b;font-size:14px;">Fetching repositories from GitHub…</div>
     </div>
+  </div>
   </div>
 
   <!-- Add to Snitch modal -->

--- a/frontend/rules.html
+++ b/frontend/rules.html
@@ -52,6 +52,7 @@
   <!-- Sidebar -->
   <div id="sidebar-mount"></div>
   <script src="/static/js/sidebar.js"></script>
+  <script src="/static/js/header.js"></script>
 
   <!-- Main -->
   <div id="main-content" style="margin-left:260px;min-height:100vh;">
@@ -62,7 +63,7 @@
         <h1 style="font-size:22px;font-weight:700;color:#f1f5f9;margin:0;">Rules Library</h1>
         <p style="font-size:13px;color:#475569;margin:2px 0 0;">Browse security rules, understand what they check, and assign them to policies</p>
       </div>
-      <div style="display:flex;gap:10px;align-items:center;">
+      <div id="header-user-slot" style="display:flex;gap:10px;align-items:center;">
         <div id="rule-counts" style="display:flex;gap:16px;align-items:center;">
           <span style="font-size:13px;color:#64748b;" id="count-catalog"></span>
           <span style="font-size:13px;color:#64748b;" id="count-discovered"></span>

--- a/frontend/secrets.html
+++ b/frontend/secrets.html
@@ -40,6 +40,7 @@
   <!-- Sidebar -->
   <div id="sidebar-mount"></div>
   <script src="/static/js/sidebar.js"></script>
+  <script src="/static/js/header.js"></script>
 
   <!-- Main -->
   <div id="main-content" style="margin-left:260px;min-height:100vh;">
@@ -48,6 +49,7 @@
         <h1 style="font-size:22px;font-weight:700;color:#f1f5f9;margin:0;">Secrets Scanner</h1>
         <p style="font-size:13px;color:#475569;margin:2px 0 0;">Credential and secret detection via Gitleaks</p>
       </div>
+      <div id="header-user-slot" style="display:flex;align-items:center;gap:8px;"></div>
     </header>
 
     <main style="padding:32px;">

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -1,0 +1,252 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Snitch — Settings</title>
+  <script>(function(){document.documentElement.setAttribute('data-theme',localStorage.getItem('theme')||'dark');})();</script>
+  <link rel="stylesheet" href="/static/css/theme.css">
+  <style>/* Inter font fallback */ body { font-family: "Inter", system-ui, -apple-system, sans-serif; }</style>
+  <script src="/static/js/lucide.min.js"></script>
+  <style>
+    * { box-sizing: border-box; }
+    @keyframes pulse { 0%,100%{opacity:1} 50%{opacity:0.5} }
+    @keyframes fadeInUp { from{transform:translateY(20px);opacity:0} to{transform:translateY(0);opacity:1} }
+    @keyframes spin { to{transform:rotate(360deg)} }
+    .card { background:rgba(13,17,23,0.8);border:1px solid rgba(255,255,255,0.08);border-radius:16px;backdrop-filter:blur(20px); }
+    .section-card { padding:28px;margin-bottom:20px;animation:fadeInUp 0.4s ease both; }
+    .section-title { font-size:16px;font-weight:700;color:#f1f5f9;margin:0 0 4px; }
+    .section-sub { font-size:13px;color:#475569;margin:0 0 24px; }
+    .pref-row { display:flex;align-items:center;justify-content:space-between;padding:14px 0;border-bottom:1px solid rgba(255,255,255,0.05); }
+    .pref-row:last-child { border-bottom:none; }
+    .pref-label { font-size:14px;font-weight:500;color:#f1f5f9; }
+    .pref-desc { font-size:12px;color:#475569;margin-top:2px; }
+    .field-group { margin-bottom:20px; }
+    .field-group:last-child { margin-bottom:0; }
+    .field-label { font-size:12px;font-weight:600;color:#64748b;text-transform:uppercase;letter-spacing:0.5px;display:block;margin-bottom:6px; }
+    .token-row { display:flex;gap:10px;align-items:center; }
+    .status-dot { width:8px;height:8px;border-radius:50%;flex-shrink:0; }
+    .status-dot-green { background:#10b981;box-shadow:0 0 6px #10b981; }
+    .status-dot-red { background:#ef4444;box-shadow:0 0 6px #ef4444; }
+    .status-dot-yellow { background:#f59e0b;box-shadow:0 0 6px #f59e0b; }
+    [data-theme="light"] .section-title { color:#0f172a; }
+    [data-theme="light"] .pref-label { color:#0f172a; }
+    [data-theme="light"] .pref-row { border-bottom-color:rgba(0,0,0,0.06); }
+  </style>
+</head>
+<body style="font-family:'Inter',system-ui,-apple-system,sans-serif;background:var(--bg-page,#0a0e1a);color:var(--text-primary,#f1f5f9);margin:0;padding:0;min-height:100vh;">
+
+  <!-- Sidebar -->
+  <div id="sidebar-mount"></div>
+  <script src="/static/js/sidebar.js"></script>
+  <script src="/static/js/header.js"></script>
+
+  <!-- Main -->
+  <div id="main-content" style="margin-left:260px;min-height:100vh;">
+    <header style="background:rgba(8,12,24,0.9);backdrop-filter:blur(20px);border-bottom:1px solid rgba(255,255,255,0.08);padding:16px 32px;display:flex;align-items:center;justify-content:space-between;position:sticky;top:0;z-index:50;">
+      <div>
+        <h1 style="font-size:22px;font-weight:700;color:#f1f5f9;margin:0;">Settings</h1>
+        <p style="font-size:13px;color:#475569;margin:2px 0 0;">Platform administration and configuration</p>
+      </div>
+      <div id="header-user-slot" style="display:flex;align-items:center;gap:8px;"></div>
+    </header>
+
+    <main style="padding:32px;max-width:900px;">
+
+      <!-- ── Integrations ── -->
+      <div class="card section-card" style="animation-delay:0s;">
+        <p class="section-title">Integrations</p>
+        <p class="section-sub">Configure external service credentials. Values are stored as presence flags only — raw secrets are never persisted in the browser.</p>
+
+        <!-- GitHub Token -->
+        <div class="field-group">
+          <label class="field-label">GitHub Token</label>
+          <p style="font-size:12px;color:#475569;margin:0 0 10px;">Required for repository discovery and GitHub code scanning sync. Needs <code style="background:rgba(255,255,255,0.07);padding:1px 5px;border-radius:4px;font-size:11px;">repo</code> and <code style="background:rgba(255,255,255,0.07);padding:1px 5px;border-radius:4px;font-size:11px;">security_events</code> scopes.</p>
+          <div class="token-row">
+            <input type="password" id="github-token-input" class="dark-input" placeholder="ghp_••••••••••••••••••••••••••••••••••••••" style="font-family:monospace;font-size:13px;flex:1;" autocomplete="off">
+            <button class="btn-secondary" id="github-toggle-btn" onclick="toggleVisibility('github-token-input','github-toggle-btn')" style="padding:10px 14px;flex-shrink:0;">
+              <i data-lucide="eye" style="width:16px;height:16px;"></i>
+            </button>
+            <button class="btn-primary" onclick="saveToken('github')" style="flex-shrink:0;white-space:nowrap;">
+              <i data-lucide="save" style="width:16px;height:16px;"></i> Save
+            </button>
+          </div>
+          <div id="github-token-status" style="margin-top:8px;font-size:12px;color:#475569;"></div>
+        </div>
+
+        <!-- Anthropic API Key -->
+        <div class="field-group">
+          <label class="field-label">Anthropic API Key</label>
+          <p style="font-size:12px;color:#475569;margin:0 0 10px;">Required for AI-powered remediation suggestions via Claude. Without this key the platform falls back to a mock remediation plan.</p>
+          <div class="token-row">
+            <input type="password" id="anthropic-token-input" class="dark-input" placeholder="sk-ant-••••••••••••••••••••••••••••••••••••••••••••••••" style="font-family:monospace;font-size:13px;flex:1;" autocomplete="off">
+            <button class="btn-secondary" id="anthropic-toggle-btn" onclick="toggleVisibility('anthropic-token-input','anthropic-toggle-btn')" style="padding:10px 14px;flex-shrink:0;">
+              <i data-lucide="eye" style="width:16px;height:16px;"></i>
+            </button>
+            <button class="btn-primary" onclick="saveToken('anthropic')" style="flex-shrink:0;white-space:nowrap;">
+              <i data-lucide="save" style="width:16px;height:16px;"></i> Save
+            </button>
+          </div>
+          <div id="anthropic-token-status" style="margin-top:8px;font-size:12px;color:#475569;"></div>
+        </div>
+      </div>
+
+      <!-- ── Platform Defaults ── -->
+      <div class="card section-card" style="animation-delay:0.08s;">
+        <p class="section-title">Platform Defaults</p>
+        <p class="section-sub">Default values used when creating new applications or triggering scans.</p>
+
+        <div class="pref-row">
+          <div>
+            <div class="pref-label">Default scan schedule</div>
+            <div class="pref-desc">Pre-selected schedule when adding a new application</div>
+          </div>
+          <select class="dark-select" id="pref-scan-schedule" onchange="savePlatformPref('scanSchedule', this.value)" style="width:180px;">
+            <option value="none">Manual only</option>
+            <option value="weekly">Weekly</option>
+            <option value="daily">Daily</option>
+          </select>
+        </div>
+
+        <div class="pref-row">
+          <div>
+            <div class="pref-label">Default scan type</div>
+            <div class="pref-desc">Pre-selected scanner when triggering a new scan</div>
+          </div>
+          <select class="dark-select" id="pref-scan-type" onchange="savePlatformPref('scanType', this.value)" style="width:180px;">
+            <option value="all">All scanners</option>
+            <option value="semgrep">SAST (Semgrep)</option>
+            <option value="trivy">SCA (Trivy)</option>
+            <option value="gitleaks">Secrets (Gitleaks)</option>
+          </select>
+        </div>
+      </div>
+
+      <!-- ── System Information ── -->
+      <div class="card section-card" style="animation-delay:0.16s;">
+        <p class="section-title">System Information</p>
+        <p class="section-sub">Read-only platform status and version details.</p>
+
+        <div class="pref-row">
+          <div>
+            <div class="pref-label">Platform version</div>
+            <div class="pref-desc">Current release of the Snitch platform</div>
+          </div>
+          <span style="font-family:monospace;font-size:13px;color:#00d4ff;background:rgba(0,212,255,0.08);border:1px solid rgba(0,212,255,0.2);padding:4px 12px;border-radius:8px;">v0.1.0</span>
+        </div>
+
+        <div class="pref-row">
+          <div>
+            <div class="pref-label">Environment</div>
+            <div class="pref-desc">Deployment context</div>
+          </div>
+          <span style="font-family:monospace;font-size:13px;color:#f59e0b;background:rgba(245,158,11,0.08);border:1px solid rgba(245,158,11,0.2);padding:4px 12px;border-radius:8px;">Development</span>
+        </div>
+
+        <div class="pref-row" style="border-bottom:none;">
+          <div>
+            <div class="pref-label">API status</div>
+            <div class="pref-desc">Backend reachability check</div>
+          </div>
+          <div id="api-status" style="display:flex;align-items:center;gap:8px;font-size:13px;color:#475569;">
+            <div style="width:16px;height:16px;border:2px solid rgba(255,255,255,0.1);border-top-color:#00d4ff;border-radius:50%;animation:spin 0.8s linear infinite;"></div>
+            Checking…
+          </div>
+        </div>
+      </div>
+
+    </main>
+  </div>
+
+<script>
+// ── Token visibility toggle ───────────────────────────────────────────────────
+
+function toggleVisibility(inputId, btnId) {
+  var input = document.getElementById(inputId);
+  var btn   = document.getElementById(btnId);
+  if (!input) return;
+  var isHidden = input.type === 'password';
+  input.type = isHidden ? 'text' : 'password';
+  btn.innerHTML = '<i data-lucide="' + (isHidden ? 'eye-off' : 'eye') + '" style="width:16px;height:16px;"></i>';
+  lucide.createIcons();
+}
+
+// ── Token save (presence flag only — raw value never persisted) ──────────────
+
+function saveToken(service) {
+  var inputId  = service + '-token-input';
+  var statusId = service + '-token-status';
+  var input    = document.getElementById(inputId);
+  var status   = document.getElementById(statusId);
+  if (!input || !input.value.trim()) {
+    status.textContent = 'Please enter a token value.';
+    status.style.color = '#ef4444';
+    return;
+  }
+  localStorage.setItem('has_' + service + '_token', '1');
+  input.value = '';
+  input.type  = 'password';
+  document.getElementById(service + '-toggle-btn').innerHTML = '<i data-lucide="eye" style="width:16px;height:16px;"></i>';
+  lucide.createIcons();
+  status.innerHTML = '<i data-lucide="check-circle" style="width:13px;height:13px;display:inline;vertical-align:middle;color:#10b981;margin-right:4px;"></i>Token saved — note: this value is not sent to the server and will need to be configured via environment variable.';
+  status.style.color = '#10b981';
+  lucide.createIcons();
+}
+
+// ── Platform preferences ─────────────────────────────────────────────────────
+
+function savePlatformPref(key, value) {
+  var prefs = JSON.parse(localStorage.getItem('platformPrefs') || '{}');
+  prefs[key] = value;
+  localStorage.setItem('platformPrefs', JSON.stringify(prefs));
+}
+
+function loadPlatformPrefs() {
+  var prefs = JSON.parse(localStorage.getItem('platformPrefs') || '{}');
+  if (prefs.scanSchedule) document.getElementById('pref-scan-schedule').value = prefs.scanSchedule;
+  if (prefs.scanType)     document.getElementById('pref-scan-type').value     = prefs.scanType;
+}
+
+// ── API status check ─────────────────────────────────────────────────────────
+
+async function checkApiStatus() {
+  var el = document.getElementById('api-status');
+  try {
+    var res = await fetch('/api/v1/applications?page=1&page_size=1');
+    if (res.ok) {
+      el.innerHTML = '<div class="status-dot status-dot-green"></div><span style="color:#10b981;font-size:13px;">Reachable</span>';
+    } else {
+      el.innerHTML = '<div class="status-dot status-dot-yellow"></div><span style="color:#f59e0b;font-size:13px;">Degraded (HTTP ' + res.status + ')</span>';
+    }
+  } catch (e) {
+    el.innerHTML = '<div class="status-dot status-dot-red"></div><span style="color:#ef4444;font-size:13px;">Unreachable</span>';
+  }
+}
+
+// ── Token presence indicators ────────────────────────────────────────────────
+
+function loadTokenStatuses() {
+  var services = ['github', 'anthropic'];
+  services.forEach(function(s) {
+    if (localStorage.getItem('has_' + s + '_token')) {
+      var el = document.getElementById(s + '-token-status');
+      if (el) {
+        el.textContent = 'A token is already saved. Enter a new value to replace it.';
+        el.style.color = '#475569';
+      }
+    }
+  });
+}
+
+// ── Init ─────────────────────────────────────────────────────────────────────
+
+(function init() {
+  applyTheme(localStorage.getItem('theme') || 'dark');
+  loadPlatformPrefs();
+  loadTokenStatuses();
+  checkApiStatus();
+  lucide.createIcons();
+})();
+</script>
+</body>
+</html>

--- a/frontend/static/js/header.js
+++ b/frontend/static/js/header.js
@@ -1,0 +1,77 @@
+/**
+ * Shared header user widget for all Snitch pages.
+ *
+ * Usage in each HTML page:
+ *   1. Add id="header-user-slot" to the right-side container in <header>.
+ *      For pages with no right-side controls, add an empty div:
+ *        <div id="header-user-slot"></div>
+ *   2. After the sidebar script:
+ *        <script src="/static/js/header.js"></script>
+ *
+ * The script injects a circular user avatar button that opens a dropdown
+ * with a Profile link and a (disabled) Logout placeholder.
+ */
+(function () {
+  var DROPDOWN_ID = 'snitch-user-dropdown';
+
+  var widgetHTML = ''
+    + '<div style="position:relative;flex-shrink:0;">'
+    +   '<button id="snitch-user-btn"'
+    +     ' onclick="window.__snitchToggleUserMenu(event)"'
+    +     ' title="Account"'
+    +     ' style="display:flex;align-items:center;justify-content:center;width:36px;height:36px;'
+    +       'background:linear-gradient(135deg,rgba(0,212,255,0.15),rgba(99,102,241,0.15));'
+    +       'border:1px solid rgba(0,212,255,0.25);border-radius:50%;cursor:pointer;'
+    +       'transition:all 0.2s;flex-shrink:0;">'
+    +     '<i data-lucide="user" style="width:18px;height:18px;color:#00d4ff;pointer-events:none;"></i>'
+    +   '</button>'
+    +   '<div id="' + DROPDOWN_ID + '"'
+    +     ' style="display:none;position:absolute;right:0;top:calc(100% + 8px);'
+    +       'background:#0d1117;border:1px solid rgba(255,255,255,0.12);border-radius:12px;'
+    +       'padding:6px;min-width:190px;z-index:500;'
+    +       'box-shadow:0 8px 32px rgba(0,0,0,0.6);">'
+    +     '<div style="padding:8px 12px 10px;border-bottom:1px solid rgba(255,255,255,0.06);margin-bottom:4px;">'
+    +       '<div style="font-size:13px;font-weight:600;color:#f1f5f9;">Admin User</div>'
+    +       '<div style="font-size:11px;color:#475569;margin-top:1px;">Platform Administrator</div>'
+    +     '</div>'
+    +     '<a href="/profile.html"'
+    +       ' style="display:flex;align-items:center;gap:8px;padding:8px 12px;border-radius:8px;'
+    +         'text-decoration:none;font-size:13px;font-weight:500;color:#94a3b8;transition:background 0.15s;"'
+    +       ' onmouseover="this.style.background=\'rgba(255,255,255,0.05)\';this.style.color=\'#f1f5f9\';"'
+    +       ' onmouseout="this.style.background=\'\';this.style.color=\'#94a3b8\';">'
+    +       '<i data-lucide="user-circle" style="width:16px;height:16px;flex-shrink:0;"></i>'
+    +       'Profile'
+    +     '</a>'
+    +     '<button disabled title="Authentication not yet enabled"'
+    +       ' style="display:flex;align-items:center;gap:8px;padding:8px 12px;border-radius:8px;'
+    +         'font-size:13px;font-weight:500;color:#475569;background:none;border:none;'
+    +         'cursor:not-allowed;width:100%;text-align:left;opacity:0.55;margin-top:2px;">'
+    +       '<i data-lucide="log-out" style="width:16px;height:16px;flex-shrink:0;"></i>'
+    +       'Logout'
+    +     '</button>'
+    +   '</div>'
+    + '</div>';
+
+  window.__snitchToggleUserMenu = function (e) {
+    if (e) e.stopPropagation();
+    var dd = document.getElementById(DROPDOWN_ID);
+    if (!dd) return;
+    dd.style.display = dd.style.display === 'none' ? 'block' : 'none';
+  };
+
+  document.addEventListener('DOMContentLoaded', function () {
+    var slot = document.getElementById('header-user-slot');
+    if (!slot) return;
+
+    slot.insertAdjacentHTML('beforeend', widgetHTML);
+
+    if (typeof lucide !== 'undefined') lucide.createIcons();
+
+    document.addEventListener('click', function (e) {
+      var btn = document.getElementById('snitch-user-btn');
+      var dd  = document.getElementById(DROPDOWN_ID);
+      if (!dd || !btn) return;
+      if (!btn.contains(e.target)) dd.style.display = 'none';
+    });
+  });
+})();

--- a/frontend/static/js/sidebar.js
+++ b/frontend/static/js/sidebar.js
@@ -23,21 +23,35 @@
     localStorage.setItem('theme', theme);
   };
 
-  // ── Nav items definition ─────────────────────────────────────────────────
-  var NAV_ITEMS = [
-    { href: '/',                icon: 'layout-dashboard', label: 'Dashboard',    matchPaths: ['/'] },
-    { href: '/applications.html', icon: 'layers',          label: 'Applications', matchPaths: ['/applications.html', '/app-detail.html'] },
-    { href: '/repositories.html', icon: 'git-branch',      label: 'Repositories', matchPaths: ['/repositories.html'] },
-    { href: '/reports.html',      icon: 'bar-chart-3',     label: 'Reports',      matchPaths: ['/reports.html'] },
-    { href: '/policies.html',     icon: 'shield-check',    label: 'Policies',     matchPaths: ['/policies.html'] },
-    { href: '/secrets.html',      icon: 'key',             label: 'Secrets',      matchPaths: ['/secrets.html'] },
-    { href: '/rules.html',        icon: 'book-open',       label: 'Rules',        matchPaths: ['/rules.html'] },
-    { href: '/profile.html',      icon: 'user',            label: 'Profile',      matchPaths: ['/profile.html'] },
+  // ── Nav sections ──────────────────────────────────────────────────────────
+  var NAV_SECTIONS = [
+    {
+      label: 'Overview',
+      items: [
+        { href: '/',                  icon: 'layout-dashboard', label: 'Dashboard',    matchPaths: ['/'] },
+        { href: '/applications.html', icon: 'layers',           label: 'Applications', matchPaths: ['/applications.html', '/app-detail.html'] },
+        { href: '/reports.html',      icon: 'bar-chart-3',      label: 'Reports',      matchPaths: ['/reports.html'] },
+        { href: '/secrets.html',      icon: 'key',              label: 'Secrets',      matchPaths: ['/secrets.html'] },
+      ]
+    },
+    {
+      label: 'Config',
+      items: [
+        { href: '/policies.html',     icon: 'shield-check',     label: 'Policies',     matchPaths: ['/policies.html'] },
+        { href: '/rules.html',        icon: 'book-open',        label: 'Rules',        matchPaths: ['/rules.html'] },
+      ]
+    },
+    {
+      label: 'Admin',
+      items: [
+        { href: '/settings.html',     icon: 'settings',         label: 'Settings',     matchPaths: ['/settings.html'] },
+        { href: '/repositories.html', icon: 'git-branch',       label: 'Repositories', matchPaths: ['/repositories.html'] },
+      ]
+    }
   ];
 
   // ── Active-link detection ────────────────────────────────────────────────
   var currentPath = window.location.pathname;
-  // Normalise: treat bare "/" and "/index.html" as the same
   if (currentPath === '/index.html') currentPath = '/';
 
   function isActive(item) {
@@ -56,7 +70,7 @@
 
   var INACTIVE_STYLE = 'color:#94a3b8';
 
-  // ── HTML builder ─────────────────────────────────────────────────────────
+  // ── HTML builders ─────────────────────────────────────────────────────────
   function navLink(item) {
     var active = isActive(item);
     var styleStr = [
@@ -79,6 +93,14 @@
       + '</a>';
   }
 
+  function sectionLabel(text) {
+    return '<div style="font-size:10px;color:#475569;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;padding:12px 8px 4px;">' + text + '</div>';
+  }
+
+  var navHTML = NAV_SECTIONS.map(function (section) {
+    return sectionLabel(section.label) + section.items.map(navLink).join('');
+  }).join('');
+
   var sidebarHTML = ''
     + '<aside id="sidebar" style="width:260px;min-height:100vh;background:#080c18;border-right:1px solid rgba(255,255,255,0.08);display:flex;flex-direction:column;position:fixed;left:0;top:0;z-index:100;">'
     +   '<div style="padding:24px 20px;border-bottom:1px solid rgba(255,255,255,0.08);display:flex;align-items:center;gap:12px;">'
@@ -90,10 +112,9 @@
     +       '<div style="font-size:11px;color:#00d4ff;font-weight:500;letter-spacing:1px;text-transform:uppercase;">AppSec Platform</div>'
     +     '</div>'
     +   '</div>'
-    +   '<nav style="flex:1;padding:16px 12px;overflow-y:auto;">'
-    +     '<div style="font-size:10px;color:#475569;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;padding:8px 8px 4px;">Main Menu</div>'
-    +     NAV_ITEMS.map(navLink).join('')
-    +     '<div style="font-size:10px;color:#475569;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;padding:16px 8px 4px;">Developer</div>'
+    +   '<nav style="flex:1;padding:8px 12px;overflow-y:auto;">'
+    +     navHTML
+    +     '<div style="font-size:10px;color:#475569;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;padding:12px 8px 4px;">Developer</div>'
     +     '<a href="/docs" class="nav-link" style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;color:#94a3b8;text-decoration:none;font-size:14px;font-weight:500;margin-bottom:2px;transition:all 0.2s;">'
     +       '<i data-lucide="code-2" style="width:18px;height:18px;flex-shrink:0;"></i> API Docs'
     +       '<i data-lucide="external-link" style="width:12px;height:12px;margin-left:auto;"></i>'


### PR DESCRIPTION
## Summary

Closes #21

- **Sidebar restructured** into three labelled sections: *Overview* (Dashboard, Applications, Reports, Secrets), *Config* (Policies, Rules), *Admin* (Settings, Repositories). Profile link removed from nav.
- **Profile widget in header** — new shared `frontend/static/js/header.js` injects a circular user-avatar button with a dropdown (Profile link + disabled Logout placeholder) into the top-right of every page's header via a `id="header-user-slot"` slot.
- **Settings page** (`/settings.html`) — new admin configuration page with Integrations (GitHub Token, Anthropic API Key stored as presence flags only), Platform Defaults (default scan schedule/type), and a read-only System Information card that pings the API to show live reachability status.
- **Applications list view** — replaced the card grid with a full-width sortable table. Default sort is risk score descending. All columns (Name, Team, Risk Score, C/H/M/L counts, Language, Last Scan) are sortable by clicking their header; active sort column shows a directional chevron.

## Test plan

- [ ] `docker compose up --build` — all pages load without console errors
- [ ] Sidebar shows three sections (Overview, Config, Admin); Profile is absent from nav; Settings and Repositories appear under Admin
- [ ] Profile avatar button appears top-right on every page; clicking opens dropdown with Profile link and greyed-out Logout
- [ ] `/settings.html` renders all three cards; API Status shows "Reachable"; token Save flow stores a presence flag without persisting the raw value
- [ ] `/applications.html` renders a table sorted by risk score descending by default; clicking Risk Score, Name, or any other column header re-sorts; filters (search, team, risk level) still work; Add Application modal still functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)