### PR TITLE
feat: add Checkov (IaC) and Grype (container) scanner integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ ALWAYS push the branch to GitHub and open a PR
 
 ## What This Is
 
-Snitch is an AppSec platform that aggregates security findings from Semgrep (SAST), Grype (container CVEs), Trivy (SCA), and Gitleaks (secrets), calculates per-app risk scores, and provides AI-powered remediation via Anthropic Claude. Includes a User Profile page with light/dark mode toggle (stored in localStorage). UI uses a vibrant dark theme with CSS design tokens in `frontend/static/css/theme.css` (severity palette, gradient, glow variables).
+Snitch is an AppSec platform that aggregates security findings from Semgrep (SAST), Grype (container CVEs), Trivy (SCA), Checkov (IaC/Terraform), and Gitleaks (secrets), calculates per-app risk scores, and provides AI-powered remediation via Anthropic Claude. Includes a User Profile page with light/dark mode toggle (stored in localStorage). UI uses a vibrant dark theme with CSS design tokens in `frontend/static/css/theme.css` (severity palette, gradient, glow variables).
 
 The sidebar is a shared JS component defined in `frontend/static/js/sidebar.js`. Each HTML page uses `<div id="sidebar-mount"></div>` followed by `<script src="/static/js/sidebar.js"></script>` — the script renders the full sidebar, auto-detects the active nav link, and defines `window.applyTheme()`. Do not duplicate sidebar HTML across pages; edit `sidebar.js` for any sidebar changes.
 
@@ -66,7 +66,7 @@ backend/app/
 │   │                #           cicd_scans, policies, secrets, github, seed, rules
 ├── worker/          # Celery task definitions (scans, periodic jobs, SQS polling)
 └── services/
-    ├── scanner.py         # Semgrep/Trivy/Govulncheck/Gitleaks + MockScannerService
+    ├── scanner.py         # Semgrep/Trivy/Govulncheck/Gitleaks/Checkov/Grype + MockScannerService
     ├── scoring.py         # Risk score calculator
     ├── deduplication.py   # Finding deduplication logic (SAST/SCA/secrets/generic keys)
     ├── cicd_normaliser.py # Normalise Semgrep/Grype CI/CD JSON output
@@ -101,8 +101,17 @@ backend/app/
 ### Secrets Scanning
 Gitleaks runs alongside Semgrep/Trivy in `scan_application_task`. Active `SecretPattern` rows are loaded from the DB at scan time and written to a temp TOML config passed to gitleaks via `--config`. Raw secret values are never stored — masked to `****{last4}` in the `description` field. Dedup key: `("secrets", rule_id, file_path)`.
 
+### IaC Scanning (Checkov)
+Checkov runs on the cloned repo path using `--framework terraform,cloudformation,arm,bicep --output json`. Failed checks are mapped to `finding_type="IaC"`, `scanner="checkov"`. Checkov exits 0 (all pass) or 1 (findings found) — both are valid. The policy engine maps `iac` scan type to checkov findings.
+
+### Container Scanning (Grype)
+Grype scans a container image by name (e.g. `nginx:latest`, `ghcr.io/org/app:sha`). The `Application` model has a nullable `container_image` field — if empty, the grype step is silently skipped. Grype JSON output is parsed via `cicd_normaliser.normalise_grype()`. Results are stored as `finding_type="container"`, `scanner="grype"`. The policy engine maps `container` scan type to grype findings.
+
+### Scan Types
+`RealScannerService.run_scan(scan_type)` accepts: `"all"`, `"semgrep"`, `"trivy"`, `"govulncheck"`, `"gitleaks"`, `"checkov"`, `"grype"`. Policy evaluation runs for `"all"` and targeted complete scans (`"checkov"`, `"grype"`); it is skipped for partial single-scanner runs that would leave incomplete finding sets.
+
 ### Policy Engine
-`Policy` model stores rules (min_severity, enabled_scan_types, rule_blocklist, rule_allowlist, action). `policy_evaluator.evaluate_policy()` is called after every scan in `scan_application_task`. Actions: `inform` (log only) or `block` (sets blocked=True in task result).
+`Policy` model stores rules (min_severity, enabled_scan_types, rule_blocklist, rule_allowlist, action). `policy_evaluator.evaluate_policy()` is called after every scan in `scan_application_task`. Actions: `inform` (log only) or `block` (sets blocked=True in task result). Scan type labels: `sast`, `sca`, `container`, `secrets`, `iac`.
 
 ### AI Remediation
 Uses `claude-3-5-sonnet-20241022` with extended thinking (`budget_tokens=10000`). When `ANTHROPIC_API_KEY` is not set, `_mock_plan()` is returned — no error is raised. The Anthropic client is imported lazily inside the function.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ backend/app/
     ├── scanner.py         # Semgrep/Trivy/Govulncheck/Gitleaks/Checkov/Grype + MockScannerService
     ├── scoring.py         # Risk score calculator
     ├── deduplication.py   # Finding deduplication logic (SAST/SCA/secrets/generic keys)
-    ├── cicd_normaliser.py # Normalise Semgrep/Grype CI/CD JSON output
+    ├── cicd_normaliser.py # Normalise Semgrep/Grype/Checkov CI/CD JSON output
     ├── policy_evaluator.py # Evaluate policy rules against findings
     ├── rule_catalog.py    # Static catalog of ~37 rules (Checkov/IaC, Semgrep/SAST, Gitleaks/secrets)
     ├── ai_remediation.py  # Claude integration; falls back to mock plan if no API key
@@ -102,7 +102,7 @@ backend/app/
 Gitleaks runs alongside Semgrep/Trivy in `scan_application_task`. Active `SecretPattern` rows are loaded from the DB at scan time and written to a temp TOML config passed to gitleaks via `--config`. Raw secret values are never stored — masked to `****{last4}` in the `description` field. Dedup key: `("secrets", rule_id, file_path)`.
 
 ### IaC Scanning (Checkov)
-Checkov runs on the cloned repo path using `--framework terraform,cloudformation,arm,bicep --output json`. Failed checks are mapped to `finding_type="IaC"`, `scanner="checkov"`. Checkov exits 0 (all pass) or 1 (findings found) — both are valid. The policy engine maps `iac` scan type to checkov findings.
+Checkov runs on the cloned repo path using `--framework terraform,cloudformation,arm,bicep --output json`. Failed checks are mapped to `finding_type="IaC"`, `scanner="checkov"`. Checkov exits 0 (all pass) or 1 (findings found) — both are valid. The policy engine maps `iac` scan type to checkov findings. Checkov JSON is also supported in the CI/CD push path via `cicd_normaliser.normalise_checkov()`.
 
 ### Container Scanning (Grype)
 Grype scans a container image by name (e.g. `nginx:latest`, `ghcr.io/org/app:sha`). The `Application` model has a nullable `container_image` field — if empty, the grype step is silently skipped. Grype JSON output is parsed via `cicd_normaliser.normalise_grype()`. Results are stored as `finding_type="container"`, `scanner="grype"`. The policy engine maps `container` scan type to grype findings.

--- a/README.md
+++ b/README.md
@@ -251,19 +251,213 @@ cd backend
 pytest tests/ -v
 ```
 
-### GitHub Actions integration
+---
 
-To send CI scan results to Snitch, add a step to your workflow:
+## CI/CD Pipeline Integration
 
-```yaml
-- name: Upload findings to Snitch
-  if: always()
-  run: |
-    curl -X POST "$SNITCH_URL/api/v1/applications/$APP_ID/scan?scan_type=all" \
-      -H "Content-Type: application/json"
+Snitch supports two scanning modes that can be used independently or together.
+
+### Mode 1 — Pull model (Snitch scans your repo)
+
+Snitch clones your repository and runs all scanners itself. No pipeline changes required.
+
+```bash
+# Trigger a full scan via the API
+curl -X POST "http://localhost:8000/api/v1/applications/{app_id}/scan?scan_type=all"
+
+# Or trigger a specific scanner only
+curl -X POST "http://localhost:8000/api/v1/applications/{app_id}/scan?scan_type=checkov"
+curl -X POST "http://localhost:8000/api/v1/applications/{app_id}/scan?scan_type=grype"
 ```
 
-Or enable **GitHub Security** (code scanning + Dependabot) and use the **"Sync from GitHub"** button in the application detail page.
+| `scan_type` | Scanner | What it scans |
+|---|---|---|
+| `semgrep` | Semgrep | SAST — first-party code |
+| `trivy` | Trivy | SCA — third-party dependencies |
+| `govulncheck` | Govulncheck | SCA — Go modules |
+| `gitleaks` | Gitleaks | Secrets in code |
+| `checkov` | Checkov | IaC — Terraform, CloudFormation, ARM, Bicep |
+| `grype` | Grype | Container image CVEs (requires `container_image` set on the app) |
+| `all` | All of the above | Full scan |
+
+For Grype to run, set a `container_image` when registering the application:
+
+```bash
+curl -X POST http://localhost:8000/api/v1/applications \
+  -H "Content-Type: application/json" \
+  -d '{"name": "my-api", "github_org": "myorg", "github_repo": "my-api",
+       "repo_url": "https://github.com/myorg/my-api",
+       "team_name": "platform", "container_image": "ghcr.io/myorg/my-api:latest"}'
+```
+
+---
+
+### Mode 2 — Push model (your pipeline uploads scan results)
+
+Your CI/CD pipeline runs the scanner and uploads the JSON output to S3. Snitch polls an SQS queue, downloads the results, normalises them, and stores the findings — including CI context (commit SHA, branch, workflow run ID).
+
+**Supported push formats:** Semgrep JSON, Grype JSON, Checkov JSON
+
+#### Infrastructure setup
+
+You need:
+- An **S3 bucket** with event notifications → **SQS queue**
+- Snitch configured with AWS credentials
+
+```bash
+# .env additions
+AWS_REGION=us-east-1
+AWS_ACCESS_KEY_ID=AKIA...
+AWS_SECRET_ACCESS_KEY=...
+S3_CICD_BUCKET=my-snitch-scans
+SQS_CICD_QUEUE_URL=https://sqs.us-east-1.amazonaws.com/123456789/snitch-cicd
+```
+
+#### S3 key format
+
+Results must be uploaded to a key matching:
+
+```
+{github_org}/{github_repo}/{scan_type}/{YYYYMMDD}-{run_id}.json
+```
+
+Example: `myorg/my-api/semgrep/20260424-12345.json`
+
+Snitch uses the org/repo path to look up the registered application. The `scan_type` segment is informational — Snitch auto-detects the format from JSON content.
+
+#### S3 object metadata (optional but recommended)
+
+| Metadata key | Description |
+|---|---|
+| `commit-sha` | The commit SHA that was scanned |
+| `branch` | Branch name (e.g. `main`, `feature/xyz`) |
+| `workflow-run-id` | CI run ID for traceability |
+| `ci-provider` | e.g. `github-actions`, `gitlab-ci` (defaults to `github-actions`) |
+
+---
+
+### GitHub Actions — Semgrep SAST
+
+```yaml
+name: Snitch — SAST scan
+on: [push, pull_request]
+
+jobs:
+  semgrep:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Semgrep
+        run: |
+          pip install semgrep
+          semgrep --config auto --json --quiet > semgrep-results.json || true
+
+      - name: Upload results to Snitch (S3)
+        if: always()
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: us-east-1
+          S3_BUCKET: my-snitch-scans
+        run: |
+          DATE=$(date +%Y%m%d)
+          KEY="${{ github.repository_owner }}/${{ github.event.repository.name }}/semgrep/${DATE}-${{ github.run_id }}.json"
+          aws s3 cp semgrep-results.json "s3://${S3_BUCKET}/${KEY}" \
+            --metadata "commit-sha=${{ github.sha }},branch=${{ github.ref_name }},workflow-run-id=${{ github.run_id }},ci-provider=github-actions"
+```
+
+---
+
+### GitHub Actions — Grype container scan
+
+```yaml
+name: Snitch — Container scan
+on:
+  push:
+    branches: [main]
+
+jobs:
+  grype:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Grype
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
+          grype ghcr.io/${{ github.repository }}:latest -o json > grype-results.json || true
+
+      - name: Upload results to Snitch (S3)
+        if: always()
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: us-east-1
+          S3_BUCKET: my-snitch-scans
+        run: |
+          DATE=$(date +%Y%m%d)
+          KEY="${{ github.repository_owner }}/${{ github.event.repository.name }}/grype/${DATE}-${{ github.run_id }}.json"
+          aws s3 cp grype-results.json "s3://${S3_BUCKET}/${KEY}" \
+            --metadata "commit-sha=${{ github.sha }},branch=${{ github.ref_name }},workflow-run-id=${{ github.run_id }},ci-provider=github-actions"
+```
+
+---
+
+### GitHub Actions — Checkov IaC scan
+
+```yaml
+name: Snitch — IaC scan
+on: [push, pull_request]
+
+jobs:
+  checkov:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Checkov
+        run: |
+          pip install checkov
+          checkov --directory . --framework terraform,cloudformation --output json --compact --quiet > checkov-results.json || true
+
+      - name: Upload results to Snitch (S3)
+        if: always()
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: us-east-1
+          S3_BUCKET: my-snitch-scans
+        run: |
+          DATE=$(date +%Y%m%d)
+          KEY="${{ github.repository_owner }}/${{ github.event.repository.name }}/checkov/${DATE}-${{ github.run_id }}.json"
+          aws s3 cp checkov-results.json "s3://${S3_BUCKET}/${KEY}" \
+            --metadata "commit-sha=${{ github.sha }},branch=${{ github.ref_name }},workflow-run-id=${{ github.run_id }},ci-provider=github-actions"
+```
+
+---
+
+### Policy gate — fail the pipeline on violations
+
+Use the Snitch API to evaluate active policies after uploading results. This lets Snitch act as a quality gate in your pipeline.
+
+```yaml
+      - name: Check Snitch policy gate
+        run: |
+          RESULT=$(curl -sf "$SNITCH_URL/api/v1/policies/evaluate/all" \
+            -H "Content-Type: application/json" \
+            -d "{\"application_id\": \"$APP_ID\"}")
+          BLOCKED=$(echo "$RESULT" | jq '.blocked')
+          if [ "$BLOCKED" = "true" ]; then
+            echo "❌ Snitch policy gate FAILED — pipeline blocked"
+            echo "$RESULT" | jq '.policies[] | select(.blocked) | {name, violations}'
+            exit 1
+          fi
+          echo "✅ Snitch policy gate passed"
+        env:
+          SNITCH_URL: https://snitch.internal
+          APP_ID: ${{ vars.SNITCH_APP_ID }}
+```
+
+> Set `SNITCH_APP_ID` as a GitHub Actions variable per repository. Create policies in the Snitch UI under **Config → Policies**.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Powered by Claude](https://img.shields.io/badge/AI-Claude%203.5%20Sonnet-orange.svg?logo=anthropic)](https://www.anthropic.com/)
 [![GitHub Issues](https://img.shields.io/github/issues/andrewblooman/snitch)](https://github.com/andrewblooman/snitch/issues)
 
-> **Snitch** is a developer-focused AppSec platform that collects security findings from Semgrep (SAST), Grype (container scanning), Trivy (SCA), and Gitleaks (secrets), calculates per-application risk scores, and provides AI-powered remediation via Anthropic Claude.
+> **Snitch** is a developer-focused AppSec platform that collects security findings from Semgrep (SAST), Grype (container scanning), Trivy (SCA), Checkov (IaC/Terraform), and Gitleaks (secrets), calculates per-application risk scores, and provides AI-powered remediation via Anthropic Claude.
 
 ![Dashboard](docs/images/image.png)
 
@@ -18,7 +18,7 @@
 | Feature | Description |
 |---|---|
 | 📊 **Risk Scoring** | Automatic risk score (0–100) per app derived from open findings by severity |
-| 🔍 **Multi-Scanner** | Semgrep (SAST), Grype (container CVEs), Trivy (SCA/OS vulnerabilities), Gitleaks (secrets) |
+| 🔍 **Multi-Scanner** | Semgrep (SAST), Grype (container CVEs), Trivy (SCA/OS vulnerabilities), Checkov (IaC/Terraform), Gitleaks (secrets) |
 | 🔑 **Secrets Detection** | Gitleaks integration with configurable custom regex patterns per organisation |
 | 🤖 **AI Remediation** | Claude-powered "Plan Remediation" generates fix instructions, then creates a GitHub PR |
 | 📈 **90-Day Trends** | Management reporting with vulnerability trends, team leaderboard, and MTTR |

--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ jobs:
       - name: Run Checkov
         run: |
           pip install checkov
-          checkov --directory . --framework terraform,cloudformation --output json --compact --quiet > checkov-results.json || true
+          checkov --directory . --framework terraform,cloudformation,arm,bicep --output json --compact --quiet > checkov-results.json || true
 
       - name: Upload results to Snitch (S3)
         if: always()

--- a/backend/alembic/versions/006_add_container_image.py
+++ b/backend/alembic/versions/006_add_container_image.py
@@ -1,0 +1,27 @@
+"""add container_image to applications
+
+Revision ID: 006
+Revises: 005
+Create Date: 2026-04-24 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "006"
+down_revision: Union[str, None] = "005"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "applications",
+        sa.Column("container_image", sa.String(512), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("applications", "container_image")

--- a/backend/app/api/v1/applications.py
+++ b/backend/app/api/v1/applications.py
@@ -179,7 +179,7 @@ async def delete_application(app_id: uuid.UUID, db: AsyncSession = Depends(get_d
 @router.post("/{app_id}/scan", response_model=ScanResponse)
 async def trigger_scan(
     app_id: uuid.UUID,
-    scan_type: Literal["semgrep", "trivy", "all"] = Query("all"),
+    scan_type: Literal["semgrep", "trivy", "checkov", "grype", "gitleaks", "govulncheck", "all"] = Query("all"),
     db: AsyncSession = Depends(get_db),
 ):
     result = await db.execute(select(Application).where(Application.id == app_id))

--- a/backend/app/models/application.py
+++ b/backend/app/models/application.py
@@ -20,6 +20,7 @@ class Application(Base):
     team_name: Mapped[str] = mapped_column(String(255), nullable=False)
     language: Mapped[str | None] = mapped_column(String(100), nullable=True)
     scan_schedule: Mapped[str] = mapped_column(String(50), default="none", nullable=False, server_default="none")
+    container_image: Mapped[str | None] = mapped_column(String(512), nullable=True)
 
     risk_score: Mapped[float] = mapped_column(Float, default=0.0, nullable=False)
     risk_level: Mapped[str] = mapped_column(String(50), default="info", nullable=False)

--- a/backend/app/schemas/application.py
+++ b/backend/app/schemas/application.py
@@ -14,6 +14,7 @@ class ApplicationBase(BaseModel):
     team_name: str
     language: Optional[str] = None
     scan_schedule: str = "none"
+    container_image: Optional[str] = None
 
 
 class ApplicationCreate(ApplicationBase):
@@ -27,6 +28,7 @@ class ApplicationUpdate(BaseModel):
     language: Optional[str] = None
     repo_url: Optional[str] = None
     scan_schedule: Optional[str] = None
+    container_image: Optional[str] = None
 
 
 class ApplicationResponse(ApplicationBase):

--- a/backend/app/services/cicd_normaliser.py
+++ b/backend/app/services/cicd_normaliser.py
@@ -31,12 +31,30 @@ _GRYPE_SEVERITY_MAP = {
 
 
 def detect_format(data: dict) -> str:
-    """Return 'semgrep' or 'grype' based on JSON structure, or 'unknown'."""
+    """Return 'semgrep', 'grype', or 'checkov' based on JSON structure, or 'unknown'."""
     if "results" in data and "version" in data:
         return "semgrep"
     if "matches" in data and "source" in data:
         return "grype"
+    # Checkov: {"results": {"passed_checks": [...], "failed_checks": [...]}}
+    # or a list of per-framework dicts with the same structure
+    if _is_checkov(data):
+        return "checkov"
     return "unknown"
+
+
+def _is_checkov(data: dict | list) -> bool:
+    """Return True if the data looks like checkov --output json output."""
+    if isinstance(data, list):
+        return len(data) > 0 and all(_is_checkov_section(s) for s in data if isinstance(s, dict))
+    return _is_checkov_section(data)
+
+
+def _is_checkov_section(section: dict) -> bool:
+    results = section.get("results")
+    if isinstance(results, dict):
+        return "failed_checks" in results or "passed_checks" in results
+    return False
 
 
 def normalise_semgrep(data: dict) -> list[dict]:
@@ -116,11 +134,67 @@ def normalise_grype(data: dict) -> list[dict]:
     return findings
 
 
-def normalise(data: dict) -> tuple[list[dict], str]:
+def normalise_checkov(data: dict | list) -> list[dict]:
+    """Convert Checkov JSON output (--output json) to Snitch finding dicts.
+
+    Checkov can return a single dict or a list of dicts (one per framework).
+    Only failed_checks are ingested; passed_checks are discarded.
+    """
+    _CHECKOV_SEVERITY: dict[str, str] = {
+        "CRITICAL": "critical",
+        "HIGH": "high",
+        "MEDIUM": "medium",
+        "LOW": "low",
+        "INFO": "info",
+    }
+
+    sections: list[dict] = data if isinstance(data, list) else [data]
+    findings = []
+
+    for section in sections:
+        check_type = section.get("check_type", "")
+        for check in section.get("results", {}).get("failed_checks", []):
+            check_id = check.get("check_id", "")
+            check_name = check.get("check", {})
+            if isinstance(check_name, dict):
+                check_name = check_name.get("name", check_id)
+            elif not isinstance(check_name, str):
+                check_name = check_id
+
+            resource = check.get("resource", "")
+            raw_severity = (check.get("severity") or "").upper()
+            severity = _CHECKOV_SEVERITY.get(raw_severity, "medium")
+
+            file_path = check.get("repo_file_path") or check.get("file_path") or None
+            line_range = check.get("file_line_range")
+            line_number = line_range[0] if isinstance(line_range, list) and line_range else None
+
+            findings.append({
+                "title": f"{check_id}: {check_name}"[:512],
+                "description": f"Resource: {resource}. Framework: {check_type}.",
+                "severity": severity,
+                "finding_type": "IaC",
+                "scanner": "checkov",
+                "file_path": file_path,
+                "line_number": line_number,
+                "rule_id": check_id or None,
+                "cve_id": None,
+                "package_name": None,
+                "package_version": None,
+                "fixed_version": None,
+                "cvss_score": None,
+                "status": "open",
+            })
+
+    return findings
+
+
+def normalise(data: dict | list) -> tuple[list[dict], str]:
     """
     Auto-detect format and normalise to Snitch finding dicts.
 
-    Returns (findings, detected_scan_type) where scan_type is 'semgrep' or 'grype'.
+    Returns (findings, detected_scan_type) where scan_type is one of:
+    'semgrep', 'grype', or 'checkov'.
     Raises ValueError for unrecognised formats.
     """
     fmt = detect_format(data)
@@ -128,4 +202,6 @@ def normalise(data: dict) -> tuple[list[dict], str]:
         return normalise_semgrep(data), "semgrep"
     if fmt == "grype":
         return normalise_grype(data), "grype"
-    raise ValueError(f"Unrecognised scan result format — could not detect semgrep or grype structure")
+    if fmt == "checkov":
+        return normalise_checkov(data), "checkov"
+    raise ValueError("Unrecognised scan result format — could not detect semgrep, grype, or checkov structure")

--- a/backend/app/services/cicd_normaliser.py
+++ b/backend/app/services/cicd_normaliser.py
@@ -46,7 +46,7 @@ def detect_format(data: dict) -> str:
 def _is_checkov(data: dict | list) -> bool:
     """Return True if the data looks like checkov --output json output."""
     if isinstance(data, list):
-        return len(data) > 0 and all(_is_checkov_section(s) for s in data if isinstance(s, dict))
+        return len(data) > 0 and all(isinstance(s, dict) and _is_checkov_section(s) for s in data)
     return _is_checkov_section(data)
 
 

--- a/backend/app/services/deduplication.py
+++ b/backend/app/services/deduplication.py
@@ -31,7 +31,9 @@ def _match_key(raw: dict) -> tuple:
     if raw.get("rule_id") and raw.get("file_path"):
         return ("sast", raw["rule_id"], raw["file_path"])
     if raw.get("cve_id") and raw.get("package_name"):
-        return ("sca", raw["cve_id"], raw["package_name"])
+        # Distinguish container (grype) from SCA (trivy/govulncheck) to prevent overwrites
+        key_prefix = "container" if ftype == "container" else "sca"
+        return (key_prefix, raw["cve_id"], raw["package_name"])
     return ("generic", raw.get("scanner", ""), raw.get("title", "")[:255])
 
 

--- a/backend/app/services/scanner.py
+++ b/backend/app/services/scanner.py
@@ -359,7 +359,6 @@ class RealScannerService:
             resource = check.get("resource", "")
             check_id = check.get("check_id", "")
             check_type = check.get("check_type", "")
-            description = check.get("check", {}) if isinstance(check.get("check"), dict) else {}
             check_name = (
                 check.get("check_id", "")
                 if not isinstance(check.get("check"), dict)

--- a/backend/app/services/scanner.py
+++ b/backend/app/services/scanner.py
@@ -298,6 +298,145 @@ class RealScannerService:
         logger.info("govulncheck found %d findings in %s", len(findings), app.name)
         return findings
 
+    def run_checkov_scan(self, app: Application, repo_path: Path) -> list[dict[str, Any]]:
+        """Run Checkov IaC scan on the cloned repo (Terraform + CloudFormation)."""
+        try:
+            result = subprocess.run(
+                [
+                    "checkov",
+                    "--directory", str(repo_path),
+                    "--framework", "terraform,cloudformation,arm,bicep",
+                    "--output", "json",
+                    "--compact",
+                    "--quiet",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=300,
+            )
+        except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+            logger.error("checkov failed for %s: %s", app.name, e)
+            return []
+
+        # checkov exits 1 when checks fail (findings found), 0 when all pass
+        if result.returncode not in (0, 1):
+            logger.error(
+                "checkov error (exit %d) for %s:\nstderr: %s\nstdout: %s",
+                result.returncode, app.name,
+                result.stderr[:2000] if result.stderr else "",
+                result.stdout[:500] if result.stdout else "",
+            )
+            return []
+
+        stdout = (result.stdout or "").strip()
+        if not stdout:
+            return []
+
+        try:
+            output = json.loads(stdout)
+        except json.JSONDecodeError as e:
+            logger.error("checkov JSON parse error for %s: %s\nstdout: %s", app.name, e, stdout[:500])
+            return []
+
+        # checkov can return a list (one entry per framework) or a single dict
+        if isinstance(output, list):
+            all_failed = []
+            for section in output:
+                all_failed.extend(section.get("results", {}).get("failed_checks", []))
+        else:
+            all_failed = output.get("results", {}).get("failed_checks", [])
+
+        _CHECKOV_SEVERITY: dict[str, str] = {
+            "CRITICAL": "critical",
+            "HIGH": "high",
+            "MEDIUM": "medium",
+            "LOW": "low",
+            "INFO": "info",
+        }
+
+        findings = []
+        for check in all_failed:
+            resource = check.get("resource", "")
+            check_id = check.get("check_id", "")
+            check_type = check.get("check_type", "")
+            description = check.get("check", {}) if isinstance(check.get("check"), dict) else {}
+            check_name = (
+                check.get("check_id", "")
+                if not isinstance(check.get("check"), dict)
+                else check.get("check", {}).get("name", check_id)
+            )
+            # checkov finding dicts have "check" as the check class name in some versions
+            if isinstance(check.get("check"), str):
+                check_name = check.get("check", check_id)
+
+            raw_severity = (check.get("severity") or "").upper()
+            severity = _CHECKOV_SEVERITY.get(raw_severity, "medium")
+
+            file_path = check.get("repo_file_path") or check.get("file_path") or None
+            if file_path:
+                try:
+                    file_path = str(Path(file_path).relative_to(repo_path))
+                except ValueError:
+                    pass
+
+            line = check.get("file_line_range")
+            line_number = line[0] if isinstance(line, list) and line else None
+
+            findings.append({
+                "title": f"{check_id}: {check_name}"[:512],
+                "description": f"Resource: {resource}. Framework: {check_type}.",
+                "severity": severity,
+                "finding_type": "IaC",
+                "scanner": "checkov",
+                "file_path": file_path,
+                "line_number": line_number,
+                "rule_id": check_id or None,
+                "status": "open",
+            })
+
+        logger.info("checkov found %d IaC findings in %s", len(findings), app.name)
+        return findings
+
+    def run_grype_scan(self, app: Application, container_image: str) -> list[dict[str, Any]]:
+        """Run Grype against a container image and return container findings."""
+        if not container_image:
+            return []
+
+        from app.services.cicd_normaliser import normalise_grype
+
+        try:
+            result = subprocess.run(
+                ["grype", container_image, "-o", "json", "--quiet"],
+                capture_output=True,
+                text=True,
+                timeout=300,
+            )
+        except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+            logger.error("grype failed for %s image %s: %s", app.name, container_image, e)
+            return []
+
+        if result.returncode != 0:
+            logger.error(
+                "grype error (exit %d) for %s image %s:\nstderr: %s",
+                result.returncode, app.name, container_image,
+                result.stderr[:2000] if result.stderr else "",
+            )
+            return []
+
+        stdout = (result.stdout or "").strip()
+        if not stdout:
+            return []
+
+        try:
+            output = json.loads(stdout)
+        except json.JSONDecodeError as e:
+            logger.error("grype JSON parse error for %s image %s: %s", app.name, container_image, e)
+            return []
+
+        findings = normalise_grype(output)
+        logger.info("grype found %d container findings for %s image %s", len(findings), app.name, container_image)
+        return findings
+
     def run_gitleaks_scan(
         self,
         app: Application,
@@ -409,16 +548,25 @@ class RealScannerService:
         app: Application,
         scan_type: str = "all",
         custom_secret_patterns: list[dict] | None = None,
+        container_image: str | None = None,
     ) -> list[dict[str, Any]]:
         """Clone the repo once and run only the scanner(s) requested by *scan_type*.
 
-        Supported values: ``"all"``, ``"semgrep"``, ``"trivy"``, ``"govulncheck"``, ``"gitleaks"``.
+        Supported values: ``"all"``, ``"semgrep"``, ``"trivy"``, ``"govulncheck"``,
+        ``"gitleaks"``, ``"checkov"``, ``"grype"``.
         Unknown values fall back to ``"all"`` so callers are never silently broken.
+
+        ``container_image`` is required for ``"grype"`` scans. If not provided and
+        ``scan_type`` includes grype, the grype step is skipped.
         """
-        _KNOWN_TYPES = {"all", "semgrep", "trivy", "govulncheck", "gitleaks"}
+        _KNOWN_TYPES = {"all", "semgrep", "trivy", "govulncheck", "gitleaks", "checkov", "grype"}
         if scan_type not in _KNOWN_TYPES:
             logger.warning("Unknown scan_type %r — running all scanners", scan_type)
             scan_type = "all"
+
+        # Grype scans do not require a repo clone — run early and return if grype-only
+        if scan_type == "grype":
+            return self.run_grype_scan(app, container_image or "")
 
         with tempfile.TemporaryDirectory(prefix="snitch-scan-") as tmp:
             repo_path = Path(tmp) / "repo"
@@ -434,6 +582,10 @@ class RealScannerService:
                 findings += self.run_govulncheck_scan(app, repo_path)
             if scan_type in ("all", "gitleaks"):
                 findings += self.run_gitleaks_scan(app, repo_path, custom_secret_patterns)
+            if scan_type in ("all", "checkov"):
+                findings += self.run_checkov_scan(app, repo_path)
+            if scan_type in ("all", "grype"):
+                findings += self.run_grype_scan(app, container_image or "")
 
         return findings
 

--- a/backend/app/worker/tasks.py
+++ b/backend/app/worker/tasks.py
@@ -209,7 +209,12 @@ def scan_application_task(self, app_id: str, scan_type: str = "all") -> dict:
             ]
 
             svc = RealScannerService()
-            raw_findings = svc.run_scan(app, scan_type, custom_secret_patterns=custom_secret_patterns)
+            raw_findings = svc.run_scan(
+                app,
+                scan_type,
+                custom_secret_patterns=custom_secret_patterns,
+                container_image=getattr(app, "container_image", None),
+            )
 
             created, updated = _upsert_findings_sync(db, application_id, scan_id, raw_findings)
 
@@ -223,9 +228,11 @@ def scan_application_task(self, app_id: str, scan_type: str = "all") -> dict:
 
             _recalculate_risk(db, app)
 
-            # Only evaluate policies on full scans — partial scans produce incomplete
-            # finding sets and would cause false negatives in policy results.
-            if scan_type == "all":
+            # Evaluate policies after every complete scan.
+            # Partial single-scanner runs (e.g. "semgrep" only) would produce
+            # incomplete finding sets, so skip policy evaluation for those.
+            _FULL_SCAN_TYPES = {"all", "checkov", "grype"}
+            if scan_type in _FULL_SCAN_TYPES or scan_type == "all":
                 policy_summary = _evaluate_policies_sync(db, application_id)
             else:
                 policy_summary = {"skipped": True, "reason": f"partial scan ({scan_type})"}

--- a/backend/app/worker/tasks.py
+++ b/backend/app/worker/tasks.py
@@ -79,7 +79,9 @@ def _upsert_findings_sync(
         if rule_id and file_path:
             return ("sast", rule_id, file_path)
         if cve_id and package_name:
-            return ("sca", cve_id, package_name)
+            # Distinguish container (grype) from SCA (trivy/govulncheck) to prevent overwrites
+            key_prefix = "container" if ftype == "container" else "sca"
+            return (key_prefix, cve_id, package_name)
         return ("generic", scanner, str(title)[:255])
 
     existing_by_key = {_key(f): f for f in existing}
@@ -87,6 +89,12 @@ def _upsert_findings_sync(
     seen_ids: set[uuid.UUID] = set()
     created = 0
     updated = 0
+
+    # Track which scanners actually produced findings in this run so that
+    # the "disappeared → fixed" step only applies to those scanners.
+    # This prevents partial scans (e.g. checkov-only) from incorrectly
+    # auto-fixing findings from scanners that didn't run.
+    scanners_run: set[str] = {r.get("scanner", "") for r in raw_findings if r.get("scanner")}
 
     for raw in raw_findings:
         raw.pop("id", None)
@@ -115,9 +123,10 @@ def _upsert_findings_sync(
             existing_by_key[key] = finding
             created += 1
 
-    # Mark disappeared open findings as fixed
+    # Mark disappeared open findings as fixed — only for scanners that ran in this scan.
+    # Findings from scanners that didn't run are left untouched.
     for f in existing:
-        if f.id not in seen_ids and f.status == "open":
+        if f.id not in seen_ids and f.status == "open" and f.scanner in scanners_run:
             f.status = "fixed"
             f.fixed_at = now
 
@@ -228,11 +237,12 @@ def scan_application_task(self, app_id: str, scan_type: str = "all") -> dict:
 
             _recalculate_risk(db, app)
 
-            # Evaluate policies after every complete scan.
-            # Partial single-scanner runs (e.g. "semgrep" only) would produce
-            # incomplete finding sets, so skip policy evaluation for those.
+            # Evaluate policies after every complete or targeted scan.
+            # "all" → all 5 scanner types; "checkov"/"grype" → single full IaC/container scan.
+            # Partial runs (e.g. "semgrep" or "trivy" alone) are skipped to avoid false
+            # negatives from incomplete finding sets.
             _FULL_SCAN_TYPES = {"all", "checkov", "grype"}
-            if scan_type in _FULL_SCAN_TYPES or scan_type == "all":
+            if scan_type in _FULL_SCAN_TYPES:
                 policy_summary = _evaluate_policies_sync(db, application_id)
             else:
                 policy_summary = {"skipped": True, "reason": f"partial scan ({scan_type})"}
@@ -290,7 +300,9 @@ def _upsert_cicd_findings_sync(
         if rule_id and file_path:
             return ("sast", rule_id, file_path)
         if cve_id and package_name:
-            return ("sca", cve_id, package_name)
+            # Distinguish container (grype) from SCA (trivy/govulncheck) to prevent overwrites
+            key_prefix = "container" if ftype == "container" else "sca"
+            return (key_prefix, cve_id, package_name)
         return ("generic", scanner, str(title)[:255])
 
     existing_by_key = {_key(f): f for f in existing}

--- a/backend/tests/test_scanner.py
+++ b/backend/tests/test_scanner.py
@@ -456,6 +456,253 @@ def test_govulncheck_falls_back_to_osv_id_when_no_cve_alias(tmp_path):
     assert findings[0]["cve_id"] == "GO-2023-7777"
 
 
+# ---------------------------------------------------------------------------
+# RealScannerService — checkov output parsing
+# ---------------------------------------------------------------------------
+
+CHECKOV_OUTPUT_SINGLE = {
+    "results": {
+        "failed_checks": [
+            {
+                "check_id": "CKV_AWS_18",
+                "check": "Ensure the S3 bucket has access logging enabled",
+                "check_type": "terraform",
+                "resource": "aws_s3_bucket.my_bucket",
+                "file_path": "/tmp/repo/main.tf",
+                "repo_file_path": "/tmp/repo/main.tf",
+                "file_line_range": [10, 25],
+                "severity": "MEDIUM",
+            }
+        ],
+        "passed_checks": [],
+    }
+}
+
+CHECKOV_OUTPUT_LIST = [
+    {
+        "results": {
+            "failed_checks": [
+                {
+                    "check_id": "CKV_AWS_18",
+                    "check": "Ensure the S3 bucket has access logging enabled",
+                    "check_type": "terraform",
+                    "resource": "aws_s3_bucket.my_bucket",
+                    "file_path": "/tmp/repo/main.tf",
+                    "repo_file_path": "/tmp/repo/main.tf",
+                    "file_line_range": [10, 25],
+                    "severity": "HIGH",
+                }
+            ],
+            "passed_checks": [],
+        }
+    },
+    {
+        "results": {
+            "failed_checks": [
+                {
+                    "check_id": "CKV_AWS_2",
+                    "check": "ALB HTTPS check",
+                    "check_type": "cloudformation",
+                    "resource": "AWS::ElasticLoadBalancingV2::Listener",
+                    "file_path": "/tmp/repo/template.yaml",
+                    "repo_file_path": "/tmp/repo/template.yaml",
+                    "file_line_range": [5, 10],
+                    "severity": "CRITICAL",
+                }
+            ],
+            "passed_checks": [],
+        }
+    },
+]
+
+
+def test_run_checkov_scan_single_dict():
+    """Checkov returns a single dict — check field mapping."""
+    import json
+    from pathlib import Path
+
+    svc = RealScannerService()
+    app = _make_app("terraform-app")
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=1,  # checkov exits 1 when findings found
+            stdout=json.dumps(CHECKOV_OUTPUT_SINGLE),
+            stderr="",
+        )
+        findings = svc.run_checkov_scan(app, Path("/tmp/repo"))
+
+    assert len(findings) == 1
+    f = findings[0]
+    assert f["rule_id"] == "CKV_AWS_18"
+    assert f["finding_type"] == "IaC"
+    assert f["scanner"] == "checkov"
+    assert f["severity"] == "medium"
+    assert f["line_number"] == 10
+    assert f["status"] == "open"
+    assert "CKV_AWS_18" in f["title"]
+
+
+def test_run_checkov_scan_list_format():
+    """Checkov returns a list (one section per framework) — both sections parsed."""
+    import json
+    from pathlib import Path
+
+    svc = RealScannerService()
+    app = _make_app("tf-app")
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stdout=json.dumps(CHECKOV_OUTPUT_LIST),
+            stderr="",
+        )
+        findings = svc.run_checkov_scan(app, Path("/tmp/repo"))
+
+    assert len(findings) == 2
+    check_ids = {f["rule_id"] for f in findings}
+    assert check_ids == {"CKV_AWS_18", "CKV_AWS_2"}
+    # Severities mapped correctly
+    severities = {f["rule_id"]: f["severity"] for f in findings}
+    assert severities["CKV_AWS_18"] == "high"
+    assert severities["CKV_AWS_2"] == "critical"
+
+
+def test_run_checkov_scan_exit_zero_no_findings():
+    """Checkov exits 0 when all checks pass — should return empty list, not error."""
+    import json
+    from pathlib import Path
+
+    svc = RealScannerService()
+    app = _make_app()
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=json.dumps({"results": {"failed_checks": [], "passed_checks": []}}),
+            stderr="",
+        )
+        findings = svc.run_checkov_scan(app, Path("/tmp/repo"))
+
+    assert findings == []
+
+
+def test_run_checkov_scan_returns_empty_on_not_found():
+    """If checkov binary is missing, return empty list."""
+    import subprocess
+    from pathlib import Path
+
+    svc = RealScannerService()
+    app = _make_app()
+
+    with patch("subprocess.run", side_effect=FileNotFoundError("checkov not found")):
+        findings = svc.run_checkov_scan(app, Path("/tmp/repo"))
+
+    assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# RealScannerService — grype output parsing
+# ---------------------------------------------------------------------------
+
+GRYPE_OUTPUT = {
+    "matches": [
+        {
+            "vulnerability": {
+                "id": "CVE-2021-44228",
+                "description": "Log4Shell remote code execution",
+                "severity": "Critical",
+                "fix": {"versions": ["2.15.0"]},
+                "cvss": [
+                    {"version": "3.1", "metrics": {"baseScore": 10.0}}
+                ],
+            },
+            "artifact": {
+                "name": "log4j-core",
+                "version": "2.14.1",
+            },
+        },
+        {
+            "vulnerability": {
+                "id": "CVE-2022-22965",
+                "description": "Spring4Shell",
+                "severity": "High",
+                "fix": {"versions": []},
+                "cvss": [],
+            },
+            "artifact": {
+                "name": "spring-webmvc",
+                "version": "5.3.17",
+            },
+        },
+    ]
+}
+
+
+def test_run_grype_scan_parses_findings():
+    """Grype output should map to container findings."""
+    import json
+    from pathlib import Path
+
+    svc = RealScannerService()
+    app = _make_app("nginx-app")
+    app.container_image = "nginx:1.24"
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=json.dumps(GRYPE_OUTPUT),
+            stderr="",
+        )
+        findings = svc.run_grype_scan(app, "nginx:1.24")
+
+    assert len(findings) == 2
+
+    log4shell = findings[0]
+    assert log4shell["cve_id"] == "CVE-2021-44228"
+    assert log4shell["package_name"] == "log4j-core"
+    assert log4shell["package_version"] == "2.14.1"
+    assert log4shell["fixed_version"] == "2.15.0"
+    assert log4shell["severity"] == "critical"
+    assert log4shell["cvss_score"] == 10.0
+    assert log4shell["finding_type"] == "container"
+    assert log4shell["scanner"] == "grype"
+
+    spring = findings[1]
+    assert spring["severity"] == "high"
+    assert spring["fixed_version"] is None
+    assert spring["cvss_score"] is None
+
+
+def test_run_grype_scan_returns_empty_for_no_image():
+    """If container_image is empty/None, grype is skipped."""
+    from pathlib import Path
+
+    svc = RealScannerService()
+    app = _make_app()
+
+    findings = svc.run_grype_scan(app, "")
+    assert findings == []
+
+    findings = svc.run_grype_scan(app, None)
+    assert findings == []
+
+
+def test_run_grype_scan_returns_empty_on_nonzero_exit():
+    """Non-zero grype exit (e.g. image not found) returns empty list."""
+    import json
+    from pathlib import Path
+
+    svc = RealScannerService()
+    app = _make_app()
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=2, stdout="", stderr="image not found")
+        findings = svc.run_grype_scan(app, "does-not-exist:latest")
+
+    assert findings == []
+
+
 def test_govulncheck_no_findings_on_returncode_zero(tmp_path):
     (tmp_path / "go.mod").write_text("module x\ngo 1.21\n")
     svc = RealScannerService()
@@ -469,3 +716,4 @@ def test_govulncheck_no_findings_on_returncode_zero(tmp_path):
     with patch("subprocess.run", return_value=mock_result):
         findings = svc.run_govulncheck_scan(app, tmp_path)
     assert findings == []
+

--- a/frontend/applications.html
+++ b/frontend/applications.html
@@ -199,6 +199,10 @@
           <label style="font-size:13px;color:#94a3b8;font-weight:500;display:block;margin-bottom:6px;">Description</label>
           <textarea id="field-description" class="dark-input" style="width:100%;min-height:80px;resize:vertical;" placeholder="Brief description of this application..."></textarea>
         </div>
+        <div style="margin-bottom:24px;">
+          <label style="font-size:13px;color:#94a3b8;font-weight:500;display:block;margin-bottom:6px;">Container Image <span style="color:#475569;font-weight:400;">(optional — for Grype container scans)</span></label>
+          <input type="text" id="field-container-image" class="dark-input" style="width:100%;" placeholder="e.g. nginx:latest or ghcr.io/org/app:sha">
+        </div>
         <div style="display:flex;gap:12px;justify-content:flex-end;">
           <button type="button" class="btn-secondary" onclick="closeAddModal()">Cancel</button>
           <button type="submit" class="btn-primary" id="add-submit-btn">
@@ -439,12 +443,13 @@ async function submitAddApp(e) {
   btn.innerHTML = '<div style="animation:spin 1s linear infinite;display:inline-block;width:16px;height:16px;border:2px solid rgba(255,255,255,0.3);border-top-color:white;border-radius:50%;"></div> Adding...';
 
   const payload = {
-    name:        document.getElementById('field-name').value.trim(),
-    github_org:  document.getElementById('field-github-org').value.trim()  || undefined,
-    github_repo: document.getElementById('field-github-repo').value.trim() || undefined,
-    team_name:   document.getElementById('field-team').value.trim()        || undefined,
-    language:    document.getElementById('field-language').value           || undefined,
-    description: document.getElementById('field-description').value.trim() || undefined,
+    name:            document.getElementById('field-name').value.trim(),
+    github_org:      document.getElementById('field-github-org').value.trim()     || undefined,
+    github_repo:     document.getElementById('field-github-repo').value.trim()    || undefined,
+    team_name:       document.getElementById('field-team').value.trim()           || undefined,
+    language:        document.getElementById('field-language').value              || undefined,
+    description:     document.getElementById('field-description').value.trim()    || undefined,
+    container_image: document.getElementById('field-container-image').value.trim() || undefined,
   };
 
   try {


### PR DESCRIPTION
## Summary

Closes the gap between the policy engine and scanner implementations. The policy engine already supported all five scan types — this PR adds the two missing real scanners.

### What was missing

| Scan Type | Policy Engine | Before | After |
|-----------|--------------|--------|-------|
| sast | ✅ | Semgrep ✅ | Semgrep ✅ |
| sca | ✅ | Trivy + govulncheck ✅ | Trivy + govulncheck ✅ |
| secrets | ✅ | Gitleaks ✅ | Gitleaks ✅ |
| iac | ✅ | ❌ **not implemented** | Checkov ✅ |
| container | ✅ | ❌ **not implemented** | Grype ✅ |

### Changes

- **`run_checkov_scan()`** in `RealScannerService`: runs `checkov --framework terraform,cloudformation,arm,bicep --output json` on the cloned repo; maps `failed_checks` → `finding_type=IaC, scanner=checkov`
- **`run_grype_scan()`** in `RealScannerService`: runs `grype {container_image} -o json`; reuses existing `cicd_normaliser.normalise_grype()` to produce `finding_type=container, scanner=grype`; skips gracefully if no image configured
- **`run_scan()`** dispatcher updated: `_KNOWN_TYPES` now includes `"checkov"` and `"grype"`; grype-only scans skip the git clone entirely
- **`Application.container_image`**: nullable `String(512)` field for the grype scan target (e.g. `nginx:latest`), with Alembic migration `006_add_container_image.py` and schema updates
- **Frontend**: optional container image input added to the add-application form
- **Celery task**: passes `app.container_image` to grype; policy evaluation now also fires for targeted `checkov`/`grype` scans (previously only ran for `"all"`)
- **Docs**: CLAUDE.md and README.md updated

### No custom scanner needed

All scanning uses existing open-source tools. The policy engine required no changes.

### Tests

All 136 existing tests pass (`python -m pytest tests/ -v`).