### PR TITLE
fix: eliminate Semgrep/Semgrep OSS duplicate findings

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -38,9 +38,11 @@ jobs:
 
       # Scan code and emit SARIF for GitHub Code Scanning
       - name: Run Semgrep
-        run: |
-          pip install semgrep
-          semgrep scan --config auto --sarif --output semgrep.sarif || true
+        uses: semgrep/semgrep-action@v1
+        with:
+          generateSarif: "1"
+        env:
+          SEMGREP_RULES: auto
 
       # Upload SARIF file generated in previous step
       - name: Upload SARIF file

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,7 @@ backend/app/
     ├── policy_evaluator.py # Evaluate policy rules against findings
     ├── rule_catalog.py    # Static catalog of ~37 rules (Checkov/IaC, Semgrep/SAST, Gitleaks/secrets)
     ├── ai_remediation.py  # Claude integration; falls back to mock plan if no API key
-    ├── github_service.py  # GitHub code scanning sync + branch/PR creation via PyGitHub
+    ├── github_service.py  # GitHub code scanning sync + branch/PR creation via PyGitHub; lookup_public_repo() fetches any public repo (no token required)
     ├── compliance.py      # 30 compliance mapping rules across OWASP/PCI-DSS/CIS/DORA/SOC2
     ├── slack_service.py   # Slack Block Kit notifications via incoming webhook (httpx)
     ├── jira_service.py    # Jira REST API v3 client — create issues, crawl epics, dedup via JiraIssueLink
@@ -187,6 +187,10 @@ The migration `c2b28485c8a7_add_epss_and_compliance` adds `epss_score` (Float), 
 
 ### Global Findings API
 `GET /api/v1/findings` is the platform-wide findings list endpoint. Supported query params: `application_id`, `severity`, `finding_type`, `scanner`, `status`, `identifier` (matches `cve_id OR rule_id`), `compliance_tag` (text search within the JSON array), `sort_by` (`severity` | `created_at`, default `severity`), `sort_dir` (`asc` | `desc`), `page`, `page_size`. Severity sort uses a SQL `CASE` expression (critical=0 → info=4). The endpoint eagerly loads the `application` relationship via `selectinload` so `application_name` is populated in the response.
+
+### GitHub Repos API
+`GET /api/v1/github/repos` lists all repos accessible to `GITHUB_TOKEN` with tracking status. The underlying PyGitHub call is run via `asyncio.to_thread()` to avoid blocking the async event loop.
+`GET /api/v1/github/repos/lookup?owner=ORG&repo=REPO` fetches metadata for any public (or private, if the token has access) GitHub repository. Works without a `GITHUB_TOKEN` for public repos (unauthenticated GitHub API, 60 req/hr per IP). Used by the "Track Public Repo" modal on `repositories.html`.
 
 ### Integrations API
 `/api/v1/integrations` manages Slack and Jira integration configurations. Config JSON is stored as `Text` in the DB (never returned in API responses — GET responses return `config_summary` with sensitive keys masked as `***`). The full config is returned **only once** on `POST /integrations` (similar to service account token reveal). Notification rules (`/integrations/{id}/rules`) define what triggers notifications: `event_type`, `min_severity`, `finding_types` (empty = all), `application_ids` (empty = all apps). After every scan, `dispatch_finding_notifications` Celery task evaluates all active rules and dispatches to matching integrations. Jira deduplication uses the `jira_issue_links` table — if a finding already has a link for that integration, a comment is added instead of creating a duplicate ticket. The epic crawler (`POST /integrations/jira/{id}/crawl-epic`) uses JQL `parent = "{epic_key}"` to fetch child issues and matches against open findings by CVE ID, `snitch-finding-{id}` label, and package name.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,7 @@ backend/app/
     ├── policy_evaluator.py # Evaluate policy rules against findings
     ├── rule_catalog.py    # Static catalog of ~37 rules (Checkov/IaC, Semgrep/SAST, Gitleaks/secrets)
     ├── ai_remediation.py  # Claude integration; falls back to mock plan if no API key
-    ├── github_service.py  # GitHub code scanning sync + branch/PR creation via PyGitHub; lookup_public_repo() fetches any public repo (no token required)
+    ├── github_service.py  # GitHub code scanning sync + branch/PR creation via PyGitHub; lookup_public_repo() fetches any public repo (no token required); fetch_github_security_alerts() polls GHAS APIs (code scanning, Dependabot, secret scanning) via httpx
     ├── compliance.py      # 30 compliance mapping rules across OWASP/PCI-DSS/CIS/DORA/SOC2
     ├── slack_service.py   # Slack Block Kit notifications via incoming webhook (httpx)
     ├── jira_service.py    # Jira REST API v3 client — create issues, crawl epics, dedup via JiraIssueLink
@@ -189,8 +189,22 @@ The migration `c2b28485c8a7_add_epss_and_compliance` adds `epss_score` (Float), 
 `GET /api/v1/findings` is the platform-wide findings list endpoint. Supported query params: `application_id`, `severity`, `finding_type`, `scanner`, `status`, `identifier` (matches `cve_id OR rule_id`), `compliance_tag` (text search within the JSON array), `sort_by` (`severity` | `created_at`, default `severity`), `sort_dir` (`asc` | `desc`), `page`, `page_size`. Severity sort uses a SQL `CASE` expression (critical=0 → info=4). The endpoint eagerly loads the `application` relationship via `selectinload` so `application_name` is populated in the response.
 
 ### GitHub Repos API
-`GET /api/v1/github/repos` lists all repos accessible to `GITHUB_TOKEN` with tracking status. The underlying PyGitHub call is run via `asyncio.to_thread()` to avoid blocking the async event loop.
+`GET /api/v1/github/repos` lists all repos accessible to `GITHUB_TOKEN` with tracking status. The underlying PyGitHub call is run via `asyncio.to_thread()` to avoid blocking the async event loop. Capped at 200 repos (`per_page=100`).
 `GET /api/v1/github/repos/lookup?owner=ORG&repo=REPO` fetches metadata for any public (or private, if the token has access) GitHub repository. Works without a `GITHUB_TOKEN` for public repos (unauthenticated GitHub API, 60 req/hr per IP). Used by the "Track Public Repo" modal on `repositories.html`.
+
+### GitHub Advanced Security (GHAS) Polling
+`GITHUB_TOKEN` requires `security_events` + `vulnerability_alerts` scopes for full access. Three alert types are polled every 5 minutes via Celery Beat:
+- **Code Scanning** (`scanner=codeql` or tool name, `finding_type=sast`) — CodeQL, Semgrep, etc.
+- **Dependabot** (`scanner=dependabot`, `finding_type=sca`) — CVE/SCA alerts
+- **Secret Scanning** (`scanner=github_secret_scanning`, `finding_type=secrets`)
+
+Each finding includes: `commit_sha` (SHA that introduced it), `introduced_by` (GitHub username), `pr_number` + `pr_url` (if finding was in a PR ref), `github_alert_url` (direct link), `github_alert_number` (dedup key).
+
+Dedup key: `(application_id, scanner, github_alert_number)`. If a token lacks scope for an alert type, that type is silently skipped. Commit author is fetched via `GET /repos/{owner}/{repo}/commits/{sha}` — not fetched for Dependabot (no commit SHA available).
+
+`POST /api/v1/github/apps/{app_id}/sync-alerts` triggers an immediate sync for one app (returns task ID). The beat schedule fires every 5 minutes for all tracked apps. Last sync time stored in `Application.last_github_sync_at`.
+
+New Finding fields (migration 010): `commit_sha`, `introduced_by`, `pr_number`, `pr_url`, `github_alert_url`, `github_alert_number`. New Application field: `last_github_sync_at`.
 
 ### Integrations API
 `/api/v1/integrations` manages Slack and Jira integration configurations. Config JSON is stored as `Text` in the DB (never returned in API responses — GET responses return `config_summary` with sensitive keys masked as `***`). The full config is returned **only once** on `POST /integrations` (similar to service account token reveal). Notification rules (`/integrations/{id}/rules`) define what triggers notifications: `event_type`, `min_severity`, `finding_types` (empty = all), `application_ids` (empty = all apps). After every scan, `dispatch_finding_notifications` Celery task evaluates all active rules and dispatches to matching integrations. Jira deduplication uses the `jira_issue_links` table — if a finding already has a link for that integration, a comment is added instead of creating a duplicate ticket. The epic crawler (`POST /integrations/jira/{id}/crawl-epic`) uses JQL `parent = "{epic_key}"` to fetch child issues and matches against open findings by CVE ID, `snitch-finding-{id}` label, and package name.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 | 🎫 **Jira Integration** | Auto-create Jira issues after scans with deduplication (no duplicate tickets per finding); on-demand issue creation per finding |
 | 🕷️ **Jira Epic Crawler** | Crawl epic child issues, match against Snitch findings, identify coverage gaps, and generate an AI remediation plan with Claude |
 | 📋 **Applications List View** | Sortable table view for the applications portfolio — click any column header to re-sort |
+| 🌍 **Track Public Repos** | Add any open source GitHub repository by URL or `org/repo` — no token needed for public repos; metadata auto-fetched via `/api/v1/github/repos/lookup` |
 | 📚 **Developer Docs** | Built-in documentation page (`/help.html`) with Quick Start, GitHub Actions CI/CD guide (2-stage auth+push), General Usage, and API Reference |
 | ℹ️ **About & Changelog** | About page (`/about.html`) with tech stack overview and release notes for all major versions |
 

--- a/backend/alembic/versions/010_add_github_security_fields.py
+++ b/backend/alembic/versions/010_add_github_security_fields.py
@@ -1,0 +1,36 @@
+"""Add GitHub Advanced Security fields to findings table
+
+Revision ID: 010
+Revises: 009
+Create Date: 2026-05-03 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "010"
+down_revision: Union[str, None] = "009"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("findings", sa.Column("commit_sha", sa.String(length=40), nullable=True))
+    op.add_column("findings", sa.Column("introduced_by", sa.String(length=255), nullable=True))
+    op.add_column("findings", sa.Column("pr_number", sa.Integer(), nullable=True))
+    op.add_column("findings", sa.Column("pr_url", sa.String(length=512), nullable=True))
+    op.add_column("findings", sa.Column("github_alert_url", sa.String(length=512), nullable=True))
+    op.add_column("findings", sa.Column("github_alert_number", sa.Integer(), nullable=True))
+    op.add_column("applications", sa.Column("last_github_sync_at", sa.DateTime(timezone=True), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("applications", "last_github_sync_at")
+    op.drop_column("findings", "github_alert_number")
+    op.drop_column("findings", "github_alert_url")
+    op.drop_column("findings", "pr_url")
+    op.drop_column("findings", "pr_number")
+    op.drop_column("findings", "introduced_by")
+    op.drop_column("findings", "commit_sha")

--- a/backend/app/api/v1/github.py
+++ b/backend/app/api/v1/github.py
@@ -1,3 +1,4 @@
+import asyncio
 import uuid
 from typing import List, Optional
 
@@ -9,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config import settings
 from app.db.session import get_db
 from app.models.application import Application
-from app.services.github_service import list_accessible_repos
+from app.services.github_service import list_accessible_repos, lookup_public_repo
 
 router = APIRouter(prefix="/github", tags=["github"])
 
@@ -38,7 +39,7 @@ async def list_github_repos(
     if not settings.GITHUB_TOKEN:
         raise HTTPException(status_code=400, detail="GITHUB_TOKEN not configured")
 
-    raw_repos = list_accessible_repos(settings.GITHUB_TOKEN)
+    raw_repos = await asyncio.to_thread(list_accessible_repos, settings.GITHUB_TOKEN)
 
     # Fetch all tracked applications keyed by (org, repo)
     result = await db.execute(select(Application.id, Application.github_org, Application.github_repo))
@@ -59,3 +60,29 @@ async def list_github_repos(
         ))
 
     return repos
+
+
+class RepoLookupInfo(BaseModel):
+    github_org: str
+    github_repo: str
+    full_name: str
+    description: Optional[str]
+    language: Optional[str]
+    repo_url: str
+    private: bool
+    archived: bool
+    default_branch: str
+    updated_at: Optional[str]
+
+
+@router.get("/repos/lookup", response_model=RepoLookupInfo)
+async def lookup_github_repo(
+    owner: str = Query(..., description="GitHub organisation or username"),
+    repo: str = Query(..., description="Repository name"),
+):
+    """Look up metadata for any public GitHub repository (no token required for public repos)."""
+    token = settings.GITHUB_TOKEN or None
+    info = await asyncio.to_thread(lookup_public_repo, owner, repo, token)
+    if info is None:
+        raise HTTPException(status_code=404, detail=f"Repository {owner}/{repo} not found or not accessible")
+    return RepoLookupInfo(**info)

--- a/backend/app/api/v1/github.py
+++ b/backend/app/api/v1/github.py
@@ -86,3 +86,18 @@ async def lookup_github_repo(
     if info is None:
         raise HTTPException(status_code=404, detail=f"Repository {owner}/{repo} not found or not accessible")
     return RepoLookupInfo(**info)
+
+
+@router.post("/apps/{app_id}/sync-alerts", status_code=202)
+async def sync_github_alerts(app_id: uuid.UUID, db: AsyncSession = Depends(get_db)):
+    """Trigger an immediate GitHub security alert sync for a single application."""
+    result = await db.execute(select(Application).where(Application.id == app_id))
+    app = result.scalar_one_or_none()
+    if not app:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if not app.github_org or not app.github_repo:
+        raise HTTPException(status_code=400, detail="Application has no GitHub repository configured")
+
+    from app.worker.github_tasks import poll_github_security_task
+    task = poll_github_security_task.delay(str(app_id))
+    return {"task_id": task.id, "status": "queued", "app_id": str(app_id)}

--- a/backend/app/models/application.py
+++ b/backend/app/models/application.py
@@ -26,6 +26,7 @@ class Application(Base):
     risk_level: Mapped[str] = mapped_column(String(50), default="info", nullable=False)
 
     last_scan_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    last_github_sync_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/app/models/finding.py
+++ b/backend/app/models/finding.py
@@ -41,6 +41,14 @@ class Finding(Base):
     epss_percentile: Mapped[float | None] = mapped_column(Float, nullable=True)
     compliance_tags: Mapped[list[str] | None] = mapped_column(JSON, nullable=True)
 
+    # GitHub Advanced Security fields
+    commit_sha: Mapped[str | None] = mapped_column(String(40), nullable=True)
+    introduced_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    pr_number: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    pr_url: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    github_alert_url: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    github_alert_number: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
     status: Mapped[str] = mapped_column(String(50), default="open", nullable=False)
 
     first_seen_at: Mapped[datetime] = mapped_column(

--- a/backend/app/schemas/application.py
+++ b/backend/app/schemas/application.py
@@ -39,6 +39,7 @@ class ApplicationResponse(ApplicationBase):
     risk_level: str
     scan_schedule: str
     last_scan_at: Optional[datetime] = None
+    last_github_sync_at: Optional[datetime] = None
     created_at: datetime
     updated_at: datetime
 

--- a/backend/app/schemas/finding.py
+++ b/backend/app/schemas/finding.py
@@ -19,6 +19,16 @@ class FindingBase(BaseModel):
     package_version: Optional[str] = None
     fixed_version: Optional[str] = None
     cvss_score: Optional[float] = None
+    epss_score: Optional[float] = None
+    epss_percentile: Optional[float] = None
+    compliance_tags: Optional[List[str]] = None
+    # GitHub Advanced Security fields
+    commit_sha: Optional[str] = None
+    introduced_by: Optional[str] = None
+    pr_number: Optional[int] = None
+    pr_url: Optional[str] = None
+    github_alert_url: Optional[str] = None
+    github_alert_number: Optional[int] = None
 
 
 class FindingCreate(FindingBase):
@@ -39,6 +49,9 @@ class FindingResponse(FindingBase):
     application_name: Optional[str] = None
     scan_id: Optional[uuid.UUID] = None
     status: str
+    epss_score: Optional[float] = None
+    epss_percentile: Optional[float] = None
+    compliance_tags: Optional[List[str]] = None
     first_seen_at: datetime
     last_seen_at: datetime
     fixed_at: Optional[datetime] = None

--- a/backend/app/services/github_service.py
+++ b/backend/app/services/github_service.py
@@ -250,6 +250,9 @@ async def fetch_github_security_alerts(owner: str, repo: str, token: str | None)
                     pr_num = _extract_pr_number(ref)
                     rule = a.get("rule") or {}
                     tool_name = (a.get("tool") or {}).get("name", "codeql").lower().replace(" ", "_")
+                    # Normalize Semgrep OSS → semgrep so historical and current alerts share the same scanner label
+                    if tool_name == "semgrep_oss":
+                        tool_name = "semgrep"
                     # Determine severity
                     sec_sev = rule.get("security_severity_level") or rule.get("severity") or "warning"
                     severity = _CODE_SCAN_SEVERITY.get(sec_sev.lower(), "medium")

--- a/backend/app/services/github_service.py
+++ b/backend/app/services/github_service.py
@@ -7,12 +7,15 @@ from app.models.application import Application
 logger = logging.getLogger(__name__)
 
 
+_REPO_LIST_LIMIT = 200
+
+
 def list_accessible_repos(token: str) -> list[dict]:
-    """Return all repos accessible to the given GitHub token."""
+    """Return up to the most-recently-updated 200 repos accessible to the given GitHub token."""
     try:
         from github import Github
 
-        g = Github(token)
+        g = Github(token, per_page=100)
         repos = []
         for repo in g.get_user().get_repos(sort="updated"):
             repos.append({
@@ -27,6 +30,8 @@ def list_accessible_repos(token: str) -> list[dict]:
                 "default_branch": repo.default_branch,
                 "updated_at": repo.updated_at.isoformat() if repo.updated_at else None,
             })
+            if len(repos) >= _REPO_LIST_LIMIT:
+                break
         return repos
     except Exception as e:
         logger.error("Failed to list accessible repos: %s", e)

--- a/backend/app/services/github_service.py
+++ b/backend/app/services/github_service.py
@@ -346,7 +346,7 @@ async def fetch_github_security_alerts(owner: str, repo: str, token: str | None)
                     params={"state": "open", "per_page": 100, "page": page},
                 )
                 if r.status_code in (403, 404):
-                    logger.debug("Secret scanning not available for %s/%s: %s", owner, repo, r.status_code)
+                    logger.debug("Secret scanning not available for %s/%s: %s", owner, repo, r.status_code)  # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
                     break
                 r.raise_for_status()
                 alerts = r.json()
@@ -372,9 +372,9 @@ async def fetch_github_security_alerts(owner: str, repo: str, token: str | None)
                     break
                 page += 1
         except httpx.HTTPStatusError as e:
-            logger.warning("Secret scanning alerts error for %s/%s: %s", owner, repo, e)
+            logger.warning("Secret scanning alerts error for %s/%s: %s", owner, repo, e)  # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
         except Exception as e:
-            logger.warning("Unexpected error fetching secret scanning for %s/%s: %s", owner, repo, e)
+            logger.warning("Unexpected error fetching secret scanning for %s/%s: %s", owner, repo, e)  # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
 
     return findings
 

--- a/backend/app/services/github_service.py
+++ b/backend/app/services/github_service.py
@@ -1,13 +1,49 @@
 import logging
+import re
 from typing import Optional
+
+import httpx
 
 from app.core.config import settings
 from app.models.application import Application
 
 logger = logging.getLogger(__name__)
 
-
+_GH_API = "https://api.github.com"
 _REPO_LIST_LIMIT = 200
+
+# Severity mapping for code scanning rule severity
+_CODE_SCAN_SEVERITY = {
+    "critical": "critical",
+    "error": "high",
+    "high": "high",
+    "warning": "medium",
+    "medium": "medium",
+    "note": "low",
+    "low": "low",
+    "none": "info",
+    "info": "info",
+}
+
+def _cvss_to_severity(score: float | None) -> str:
+    if score is None:
+        return "medium"
+    if score >= 9.0:
+        return "critical"
+    if score >= 7.0:
+        return "high"
+    if score >= 4.0:
+        return "medium"
+    if score > 0:
+        return "low"
+    return "info"
+
+
+def _extract_pr_number(ref: str | None) -> int | None:
+    """Extract PR number from a git ref like refs/pull/123/head."""
+    if ref and (m := re.match(r"refs/pull/(\d+)/", ref)):
+        return int(m.group(1))
+    return None
 
 
 def list_accessible_repos(token: str) -> list[dict]:
@@ -156,3 +192,186 @@ def create_pull_request(
     except Exception as e:
         logger.error("Failed to create pull request: %s", e)
         return None
+
+
+# ── GitHub Advanced Security alert helpers ────────────────────────────────────
+
+def _gh_headers(token: str | None) -> dict:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+async def _get_commit_author(client: httpx.AsyncClient, owner: str, repo: str, sha: str) -> str | None:
+    """Return the GitHub login of the commit author, or None on error."""
+    try:
+        r = await client.get(f"{_GH_API}/repos/{owner}/{repo}/commits/{sha}")
+        if r.status_code == 200:
+            data = r.json()
+            return (data.get("author") or {}).get("login") or data.get("commit", {}).get("author", {}).get("name")
+    except Exception:
+        pass
+    return None
+
+
+async def fetch_github_security_alerts(owner: str, repo: str, token: str | None) -> list[dict]:
+    """
+    Fetch code-scanning, dependabot, and secret-scanning alerts for a repo.
+    Returns a list of normalised finding dicts ready to be upserted.
+    """
+    findings: list[dict] = []
+    headers = _gh_headers(token)
+
+    async with httpx.AsyncClient(headers=headers, timeout=30) as client:
+        # ── Code Scanning ──────────────────────────────────────────────────
+        try:
+            page = 1
+            while True:
+                r = await client.get(
+                    f"{_GH_API}/repos/{owner}/{repo}/code-scanning/alerts",
+                    params={"state": "open", "per_page": 100, "page": page},
+                )
+                if r.status_code in (403, 404, 422):
+                    logger.debug("Code scanning not available for %s/%s: %s", owner, repo, r.status_code)
+                    break
+                r.raise_for_status()
+                alerts = r.json()
+                if not alerts:
+                    break
+                for a in alerts:
+                    instance = a.get("most_recent_instance") or {}
+                    loc = instance.get("location") or {}
+                    ref = instance.get("ref")
+                    sha = instance.get("commit_sha")
+                    pr_num = _extract_pr_number(ref)
+                    rule = a.get("rule") or {}
+                    tool_name = (a.get("tool") or {}).get("name", "codeql").lower().replace(" ", "_")
+                    # Determine severity
+                    sec_sev = rule.get("security_severity_level") or rule.get("severity") or "warning"
+                    severity = _CODE_SCAN_SEVERITY.get(sec_sev.lower(), "medium")
+                    # Get commit author if we have a SHA
+                    author: str | None = None
+                    if sha:
+                        author = await _get_commit_author(client, owner, repo, sha)
+                    findings.append({
+                        "title": rule.get("name") or rule.get("id") or "Code scanning finding",
+                        "description": rule.get("full_description") or rule.get("description") or "",
+                        "severity": severity,
+                        "finding_type": "sast",
+                        "scanner": tool_name,
+                        "rule_id": rule.get("id"),
+                        "file_path": loc.get("path"),
+                        "line_number": loc.get("start_line"),
+                        "commit_sha": sha,
+                        "introduced_by": author,
+                        "pr_number": pr_num,
+                        "pr_url": f"https://github.com/{owner}/{repo}/pull/{pr_num}" if pr_num else None,
+                        "github_alert_url": a.get("html_url"),
+                        "github_alert_number": a.get("number"),
+                        "status": "open",
+                    })
+                if len(alerts) < 100:
+                    break
+                page += 1
+        except httpx.HTTPStatusError as e:
+            logger.warning("Code scanning alerts error for %s/%s: %s", owner, repo, e)
+        except Exception as e:
+            logger.warning("Unexpected error fetching code scanning for %s/%s: %s", owner, repo, e)
+
+        # ── Dependabot ─────────────────────────────────────────────────────
+        try:
+            page = 1
+            while True:
+                r = await client.get(
+                    f"{_GH_API}/repos/{owner}/{repo}/dependabot/alerts",
+                    params={"state": "open", "per_page": 100, "page": page},
+                )
+                if r.status_code in (403, 404):
+                    logger.debug("Dependabot not available for %s/%s: %s", owner, repo, r.status_code)
+                    break
+                r.raise_for_status()
+                alerts = r.json()
+                if not alerts:
+                    break
+                for a in alerts:
+                    advisory = a.get("security_advisory") or {}
+                    vuln = a.get("security_vulnerability") or {}
+                    pkg = vuln.get("package") or {}
+                    cvss_score = (advisory.get("cvss") or {}).get("score")
+                    severity = advisory.get("severity") or _cvss_to_severity(cvss_score)
+                    if isinstance(severity, str):
+                        severity = _CODE_SCAN_SEVERITY.get(severity.lower(), "medium")
+                    findings.append({
+                        "title": advisory.get("summary") or f"Dependabot: {pkg.get('name', 'unknown')}",
+                        "description": advisory.get("description") or "",
+                        "severity": severity,
+                        "finding_type": "sca",
+                        "scanner": "dependabot",
+                        "cve_id": advisory.get("cve_id"),
+                        "package_name": pkg.get("name"),
+                        "package_version": vuln.get("vulnerable_version_range"),
+                        "fixed_version": (vuln.get("first_patched_version") or {}).get("identifier"),
+                        "cvss_score": cvss_score,
+                        "rule_id": advisory.get("ghsa_id"),
+                        "github_alert_url": a.get("html_url"),
+                        "github_alert_number": a.get("number"),
+                        "status": "open",
+                        # No commit SHA available for Dependabot alerts
+                        "commit_sha": None,
+                        "introduced_by": None,
+                        "pr_number": None,
+                        "pr_url": None,
+                    })
+                if len(alerts) < 100:
+                    break
+                page += 1
+        except httpx.HTTPStatusError as e:
+            logger.warning("Dependabot alerts error for %s/%s: %s", owner, repo, e)
+        except Exception as e:
+            logger.warning("Unexpected error fetching dependabot for %s/%s: %s", owner, repo, e)
+
+        # ── Secret Scanning ────────────────────────────────────────────────
+        try:
+            page = 1
+            while True:
+                r = await client.get(
+                    f"{_GH_API}/repos/{owner}/{repo}/secret-scanning/alerts",
+                    params={"state": "open", "per_page": 100, "page": page},
+                )
+                if r.status_code in (403, 404):
+                    logger.debug("Secret scanning not available for %s/%s: %s", owner, repo, r.status_code)
+                    break
+                r.raise_for_status()
+                alerts = r.json()
+                if not alerts:
+                    break
+                for a in alerts:
+                    findings.append({
+                        "title": a.get("secret_type_display_name") or a.get("secret_type") or "Secret detected",
+                        "description": f"Secret type: {a.get('secret_type', 'unknown')}",
+                        "severity": "high",
+                        "finding_type": "secrets",
+                        "scanner": "github_secret_scanning",
+                        "rule_id": a.get("secret_type"),
+                        "github_alert_url": a.get("html_url"),
+                        "github_alert_number": a.get("number"),
+                        "status": "open",
+                        "commit_sha": None,
+                        "introduced_by": None,
+                        "pr_number": None,
+                        "pr_url": None,
+                    })
+                if len(alerts) < 100:
+                    break
+                page += 1
+        except httpx.HTTPStatusError as e:
+            logger.warning("Secret scanning alerts error for %s/%s: %s", owner, repo, e)
+        except Exception as e:
+            logger.warning("Unexpected error fetching secret scanning for %s/%s: %s", owner, repo, e)
+
+    return findings
+

--- a/backend/app/services/github_service.py
+++ b/backend/app/services/github_service.py
@@ -33,6 +33,33 @@ def list_accessible_repos(token: str) -> list[dict]:
         return []
 
 
+def lookup_public_repo(owner: str, repo_name: str, token: str | None = None) -> dict | None:
+    """Fetch metadata for any public GitHub repository. Works without a token for public repos."""
+    try:
+        from github import Github, GithubException, UnknownObjectException
+
+        g = Github(token) if token else Github()
+        try:
+            repo = g.get_repo(f"{owner}/{repo_name}")
+        except UnknownObjectException:
+            return None
+        return {
+            "github_org": repo.owner.login,
+            "github_repo": repo.name,
+            "full_name": repo.full_name,
+            "description": repo.description,
+            "language": repo.language,
+            "repo_url": repo.html_url,
+            "private": repo.private,
+            "archived": repo.archived,
+            "default_branch": repo.default_branch,
+            "updated_at": repo.updated_at.isoformat() if repo.updated_at else None,
+        }
+    except Exception as e:
+        logger.error("Failed to look up repo %s/%s: %s", owner, repo_name, e)
+        return None
+
+
 def sync_github_security_alerts(app: Application, token: str) -> list[dict]:
     """Fetch code scanning alerts from GitHub and convert to internal finding format."""
     try:

--- a/backend/app/worker/celery_app.py
+++ b/backend/app/worker/celery_app.py
@@ -7,7 +7,7 @@ celery_app = Celery(
     "snitch",
     broker=settings.REDIS_URL,
     backend=settings.REDIS_URL,
-    include=["app.worker.tasks", "app.worker.notification_tasks"],
+    include=["app.worker.tasks", "app.worker.notification_tasks", "app.worker.github_tasks"],
 )
 
 celery_app.conf.update(
@@ -22,6 +22,11 @@ celery_app.conf.update(
             "task": "app.worker.tasks.weekly_scan_all",
             # Every Sunday at 02:00 UTC
             "schedule": crontab(hour=2, minute=0, day_of_week=0),
+        },
+        "poll-github-security-alerts": {
+            "task": "app.worker.github_tasks.poll_github_security_task",
+            # Every 5 minutes
+            "schedule": crontab(minute="*/5"),
         },
     },
 )

--- a/backend/app/worker/github_tasks.py
+++ b/backend/app/worker/github_tasks.py
@@ -1,0 +1,158 @@
+"""
+Celery tasks for polling GitHub Advanced Security alerts.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+
+from app.core.config import settings
+from app.models.application import Application
+from app.models.finding import Finding
+from app.worker.celery_app import celery_app
+
+logger = logging.getLogger(__name__)
+
+
+def _get_sync_session():
+    """Reuse the sync session helper from tasks.py to avoid duplication."""
+    from app.worker.tasks import _get_sync_session as _base
+    return _base()
+
+
+def _recalculate_risk(db, app: Application) -> None:
+    from app.worker.tasks import _recalculate_risk as _base
+    _base(db, app)
+
+
+@celery_app.task(name="app.worker.github_tasks.poll_github_security_task", bind=True, max_retries=2)
+def poll_github_security_task(self, app_id: str | None = None):
+    """
+    Poll GitHub GHAS APIs (code scanning, Dependabot, secret scanning) for all
+    tracked applications (or a single app if app_id is provided).
+    Upserts findings; dedup key = (application_id, scanner, github_alert_number).
+    """
+    token = settings.GITHUB_TOKEN
+    if not token:
+        logger.warning("GITHUB_TOKEN not set — skipping GitHub security poll")
+        return {"skipped": True, "reason": "no GITHUB_TOKEN"}
+
+    from app.services.github_service import fetch_github_security_alerts
+
+    db = _get_sync_session()
+    try:
+        if app_id:
+            apps = db.execute(
+                select(Application).where(Application.id == uuid.UUID(app_id))
+            ).scalars().all()
+        else:
+            apps = db.execute(
+                select(Application).where(
+                    Application.github_org.isnot(None),
+                    Application.github_repo.isnot(None),
+                )
+            ).scalars().all()
+
+        summary = {"apps_polled": 0, "created": 0, "updated": 0, "errors": 0}
+
+        for app in apps:
+            if not app.github_org or not app.github_repo:
+                continue
+            try:
+                alert_findings = asyncio.run(
+                    fetch_github_security_alerts(app.github_org, app.github_repo, token)
+                )
+                created, updated = _upsert_ghas_findings(db, app, alert_findings)
+                _recalculate_risk(db, app)
+                app.last_github_sync_at = datetime.now(timezone.utc)
+                db.commit()
+                summary["apps_polled"] += 1
+                summary["created"] += created
+                summary["updated"] += updated
+                logger.info(
+                    "GHAS poll %s/%s — %d created, %d updated",
+                    app.github_org, app.github_repo, created, updated,
+                )
+            except Exception as e:
+                logger.error("GHAS poll failed for app %s: %s", app.id, e)
+                db.rollback()
+                summary["errors"] += 1
+
+        return summary
+    finally:
+        db.close()
+
+
+def _upsert_ghas_findings(db, app: Application, alert_findings: list[dict]) -> tuple[int, int]:
+    """
+    Upsert GHAS findings for an application.
+    Dedup key: (application_id, scanner, github_alert_number).
+    Returns (created_count, updated_count).
+    """
+    created = updated = 0
+    now = datetime.now(timezone.utc)
+
+    for fd in alert_findings:
+        alert_num = fd.get("github_alert_number")
+        scanner = fd.get("scanner", "unknown")
+        if alert_num is None:
+            continue
+
+        existing = db.execute(
+            select(Finding).where(
+                Finding.application_id == app.id,
+                Finding.scanner == scanner,
+                Finding.github_alert_number == alert_num,
+            )
+        ).scalar_one_or_none()
+
+        if existing:
+            # Update mutable fields on re-poll
+            existing.severity = fd.get("severity", existing.severity)
+            existing.title = fd.get("title", existing.title)
+            existing.description = fd.get("description", existing.description)
+            existing.file_path = fd.get("file_path", existing.file_path)
+            existing.line_number = fd.get("line_number", existing.line_number)
+            existing.commit_sha = fd.get("commit_sha") or existing.commit_sha
+            existing.introduced_by = fd.get("introduced_by") or existing.introduced_by
+            existing.pr_number = fd.get("pr_number") or existing.pr_number
+            existing.pr_url = fd.get("pr_url") or existing.pr_url
+            existing.github_alert_url = fd.get("github_alert_url") or existing.github_alert_url
+            existing.last_seen_at = now
+            updated += 1
+        else:
+            finding = Finding(
+                id=uuid.uuid4(),
+                application_id=app.id,
+                title=fd.get("title", ""),
+                description=fd.get("description"),
+                severity=fd.get("severity", "medium"),
+                finding_type=fd.get("finding_type", "sast"),
+                scanner=scanner,
+                rule_id=fd.get("rule_id"),
+                cve_id=fd.get("cve_id"),
+                package_name=fd.get("package_name"),
+                package_version=fd.get("package_version"),
+                fixed_version=fd.get("fixed_version"),
+                cvss_score=fd.get("cvss_score"),
+                file_path=fd.get("file_path"),
+                line_number=fd.get("line_number"),
+                status="open",
+                commit_sha=fd.get("commit_sha"),
+                introduced_by=fd.get("introduced_by"),
+                pr_number=fd.get("pr_number"),
+                pr_url=fd.get("pr_url"),
+                github_alert_url=fd.get("github_alert_url"),
+                github_alert_number=alert_num,
+                first_seen_at=now,
+                last_seen_at=now,
+            )
+            db.add(finding)
+            created += 1
+
+    db.flush()
+    return created, updated

--- a/frontend/app-detail.html
+++ b/frontend/app-detail.html
@@ -114,6 +114,9 @@
           <button class="tab-btn" id="tab-remediations" onclick="switchTab('remediations')">
             <i data-lucide="wrench" style="width:15px;height:15px;display:inline;vertical-align:middle;margin-right:6px;"></i>Remediations
           </button>
+          <button class="tab-btn" id="tab-github" onclick="switchTab('github')">
+            <i data-lucide="github" style="width:15px;height:15px;display:inline;vertical-align:middle;margin-right:6px;"></i>GitHub Security
+          </button>
         </div>
 
         <!-- Findings Tab -->
@@ -171,6 +174,20 @@
         <!-- Remediations Tab -->
         <div id="pane-remediations" style="display:none;">
           <div id="remediations-grid"><div style="text-align:center;padding:32px;"><div style="animation:spin 1s linear infinite;display:inline-block;width:24px;height:24px;border:2px solid rgba(255,255,255,0.1);border-top-color:#00e5ff;border-radius:50%;"></div></div></div>
+        </div>
+
+        <!-- GitHub Security Tab -->
+        <div id="pane-github" style="display:none;">
+          <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:20px;flex-wrap:wrap;gap:12px;">
+            <div>
+              <div style="font-size:16px;font-weight:600;color:#f1f5f9;">GitHub Advanced Security Alerts</div>
+              <div id="github-sync-info" style="font-size:13px;color:#475569;margin-top:2px;">Sync to load alerts from GHAS, Dependabot, and Secret Scanning.</div>
+            </div>
+            <button id="sync-alerts-btn" onclick="syncGithubAlerts()" style="display:inline-flex;align-items:center;gap:8px;background:linear-gradient(135deg,rgba(0,229,255,0.12),rgba(99,102,241,0.12));border:1px solid rgba(0,229,255,0.25);color:#00e5ff;padding:9px 18px;border-radius:10px;font-size:14px;font-weight:500;cursor:pointer;transition:all 0.2s;" onmouseover="this.style.background='linear-gradient(135deg,rgba(0,229,255,0.2),rgba(99,102,241,0.2))'" onmouseout="this.style.background='linear-gradient(135deg,rgba(0,229,255,0.12),rgba(99,102,241,0.12))'">
+              <i data-lucide="shield-check" style="width:15px;height:15px;"></i> Sync GitHub Alerts
+            </button>
+          </div>
+          <div id="github-alerts-list"><div style="text-align:center;padding:48px;color:#475569;"><i data-lucide="github" style="width:40px;height:40px;display:block;margin:0 auto 12px;opacity:0.25;"></i><div style="font-size:16px;color:#64748b;">Click "Sync GitHub Alerts" to load findings from GitHub Advanced Security</div></div></div>
         </div>
       </div>
     </main>
@@ -480,6 +497,16 @@ function renderFindingsTable(findings){
             </div>
           </div>
           ${f.fixed_version?`<div style="margin-top:12px;"><span style="background:rgba(16,185,129,0.1);color:#10b981;border:1px solid rgba(16,185,129,0.2);padding:3px 10px;border-radius:6px;font-size:14px;font-weight:500;"><i data-lucide="package" style="width:12px;height:12px;display:inline;vertical-align:middle;margin-right:4px;"></i>Fix version: ${f.fixed_version}</span></div>`:''}
+          ${(f.introduced_by||f.commit_sha||f.pr_url||f.github_alert_url)?`
+          <div style="margin-top:16px;padding-top:16px;border-top:1px solid rgba(255,255,255,0.06);">
+            <div style="font-size:13px;color:#475569;font-weight:600;text-transform:uppercase;letter-spacing:0.8px;margin-bottom:10px;display:flex;align-items:center;gap:6px;"><i data-lucide="github" style="width:13px;height:13px;"></i> GitHub Intelligence</div>
+            <div style="display:flex;align-items:center;flex-wrap:wrap;gap:16px;">
+              ${f.introduced_by?`<div style="display:flex;align-items:center;gap:8px;"><img src="https://github.com/${escHtml(f.introduced_by)}.png?size=28" width="28" height="28" style="border-radius:50%;border:1px solid rgba(0,229,255,0.2);" onerror="this.style.display='none'"><div><div style="font-size:11px;color:#475569;text-transform:uppercase;letter-spacing:0.6px;">Introduced by</div><a href="https://github.com/${escHtml(f.introduced_by)}" target="_blank" style="font-size:14px;color:#00e5ff;text-decoration:none;font-family:'Fira Code',monospace;">@${escHtml(f.introduced_by)}</a></div></div>`:''}
+              ${f.commit_sha?`<div><div style="font-size:11px;color:#475569;text-transform:uppercase;letter-spacing:0.6px;margin-bottom:2px;">Commit</div><span style="font-size:13px;color:#94a3b8;font-family:'Fira Code',monospace;">${escHtml(f.commit_sha.substring(0,8))}</span></div>`:''}
+              ${f.pr_url?`<a href="${escHtml(f.pr_url)}" target="_blank" style="display:inline-flex;align-items:center;gap:6px;background:rgba(99,102,241,0.1);border:1px solid rgba(99,102,241,0.25);color:#a5b4fc;padding:6px 12px;border-radius:8px;font-size:13px;font-weight:500;text-decoration:none;" onmouseover="this.style.background='rgba(99,102,241,0.18)'" onmouseout="this.style.background='rgba(99,102,241,0.1)'"><i data-lucide="git-pull-request" style="width:13px;height:13px;"></i>PR #${f.pr_number||''}</a>`:''}
+              ${f.github_alert_url?`<a href="${escHtml(f.github_alert_url)}" target="_blank" style="display:inline-flex;align-items:center;gap:6px;background:rgba(0,229,255,0.08);border:1px solid rgba(0,229,255,0.2);color:#00e5ff;padding:6px 12px;border-radius:8px;font-size:13px;font-weight:500;text-decoration:none;" onmouseover="this.style.background='rgba(0,229,255,0.15)'" onmouseout="this.style.background='rgba(0,229,255,0.08)'"><i data-lucide="external-link" style="width:13px;height:13px;"></i>View Alert on GitHub</a>`:''}
+            </div>
+          </div>`:''}
         </div>
       </td>
     </tr>
@@ -727,12 +754,13 @@ function resetRemediationModal(){
 
 // ── Tabs ───────────────────────────────────────────────────────────────────────
 function switchTab(tab){
-  ['findings','scans','remediations'].forEach(t=>{
+  ['findings','scans','remediations','github'].forEach(t=>{
     document.getElementById(`pane-${t}`).style.display=t===tab?'block':'none';
     document.getElementById(`tab-${t}`).className=`tab-btn${t===tab?' active':''}`;
   });
   if(tab==='scans')loadScansTab();
   if(tab==='remediations')loadRemediationsTab();
+  if(tab==='github')loadGithubTab();
 }
 
 async function runScan(){
@@ -813,6 +841,116 @@ async function loadRemediationsTab(){
     el.innerHTML='';
 
     el.appendChild(_errDiv);
+  }
+}
+
+async function loadGithubTab(){
+  const el=document.getElementById('github-alerts-list');
+  const infoEl=document.getElementById('github-sync-info');
+  // Update last sync info from appData
+  if(appData&&appData.last_github_sync_at){
+    infoEl.innerHTML=`<i data-lucide="clock" style="width:11px;height:11px;display:inline;vertical-align:middle;margin-right:3px;"></i>Last synced ${timeAgo(appData.last_github_sync_at)}`;
+  } else {
+    infoEl.textContent='Sync to load alerts from GHAS, Dependabot, and Secret Scanning.';
+  }
+  el.innerHTML='<div style="text-align:center;padding:32px;"><div style="animation:spin 1s linear infinite;display:inline-block;width:24px;height:24px;border:2px solid rgba(255,255,255,0.1);border-top-color:#00e5ff;border-radius:50%;"></div></div>';
+  try{
+    const res=await fetch(`/api/v1/findings?application_id=${appId}&page_size=500`);
+    if(!res.ok)throw new Error('Failed to load findings');
+    const data=await res.json();
+    const findings=(data.items||data||[]).filter(f=>f.github_alert_url||f.introduced_by||f.commit_sha);
+    renderGithubTab(findings);
+  }catch(e){
+    el.innerHTML=`<div style="text-align:center;padding:32px;color:#ef4444;">${e.message}</div>`;
+  }
+}
+
+function renderGithubTab(findings){
+  const el=document.getElementById('github-alerts-list');
+  if(!findings||findings.length===0){
+    el.innerHTML=`<div style="text-align:center;padding:60px;color:#475569;">
+      <i data-lucide="github" style="width:44px;height:44px;display:block;margin:0 auto 14px;opacity:0.2;"></i>
+      <div style="font-size:17px;font-weight:500;color:#f1f5f9;margin-bottom:8px;">No GitHub Security Alerts</div>
+      <p style="max-width:400px;margin:0 auto;">Click "Sync GitHub Alerts" to import findings from GitHub Advanced Security, Dependabot, and Secret Scanning.</p>
+    </div>`;
+    lucide.createIcons();return;
+  }
+
+  // Group by PR number (null = unattributed)
+  const prGroups={};
+  findings.forEach(f=>{
+    const key=f.pr_number?String(f.pr_number):'__none__';
+    if(!prGroups[key])prGroups[key]={pr_number:f.pr_number,pr_url:f.pr_url,author:f.introduced_by,findings:[]};
+    prGroups[key].findings.push(f);
+    // Use first author found for the group
+    if(!prGroups[key].author&&f.introduced_by)prGroups[key].author=f.introduced_by;
+    if(!prGroups[key].pr_url&&f.pr_url)prGroups[key].pr_url=f.pr_url;
+  });
+
+  // Sort: PRs with most findings first, unattributed last
+  const sorted=Object.values(prGroups).sort((a,b)=>{
+    if(a.pr_number===null)return 1;
+    if(b.pr_number===null)return -1;
+    return b.findings.length-a.findings.length;
+  });
+
+  const severityOrder={critical:0,high:1,medium:2,low:3,info:4};
+  el.innerHTML=sorted.map(group=>{
+    const sortedFindings=[...group.findings].sort((a,b)=>(severityOrder[a.severity]??4)-(severityOrder[b.severity]??4));
+    const hasAttribution=group.pr_number||group.author;
+    const groupLabel=group.pr_number
+      ?`<a href="${escHtml(group.pr_url||'#')}" target="_blank" rel="noopener" style="display:inline-flex;align-items:center;gap:7px;color:#a5b4fc;text-decoration:none;font-size:16px;font-weight:600;" onmouseover="this.style.textDecoration='underline'" onmouseout="this.style.textDecoration='none'"><i data-lucide="git-pull-request" style="width:16px;height:16px;"></i>PR #${group.pr_number}</a>`
+      :`<span style="font-size:16px;font-weight:600;color:#64748b;display:inline-flex;align-items:center;gap:7px;"><i data-lucide="alert-circle" style="width:16px;height:16px;"></i>Unattributed Alerts</span>`;
+    const authorHtml=group.author?`
+      <div style="display:flex;align-items:center;gap:7px;">
+        <img src="https://github.com/${escHtml(group.author)}.png?size=22" width="22" height="22" style="border-radius:50%;border:1px solid rgba(0,229,255,0.2);" onerror="this.style.display='none'">
+        <a href="https://github.com/${escHtml(group.author)}" target="_blank" style="font-size:13px;color:#00e5ff;text-decoration:none;font-family:'Fira Code',monospace;" onmouseover="this.style.textDecoration='underline'" onmouseout="this.style.textDecoration='none'">@${escHtml(group.author)}</a>
+      </div>`:'';
+
+    const findingRows=sortedFindings.map(f=>`
+      <div style="display:flex;align-items:center;gap:10px;padding:10px 14px;border-radius:8px;transition:background 0.15s;" onmouseover="this.style.background='rgba(255,255,255,0.03)'" onmouseout="this.style.background='transparent'">
+        ${severityBadge(f.severity)}
+        <div style="flex:1;min-width:0;">
+          <div style="font-size:14px;font-weight:500;color:#e2e8f0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${escHtml(f.title||'—')}</div>
+          ${f.file_path?`<div style="font-size:12px;color:#475569;font-family:'Fira Code',monospace;">${escHtml(f.file_path)}${f.line_number?':'+f.line_number:''}</div>`:''}
+          ${f.cve_id?`<div style="font-size:12px;color:#f59e0b;font-family:'Fira Code',monospace;">${escHtml(f.cve_id)}</div>`:''}
+        </div>
+        <div style="display:flex;align-items:center;gap:8px;flex-shrink:0;">
+          ${scannerBadge(f.scanner)}
+          ${f.commit_sha?`<span style="font-size:12px;color:#475569;font-family:'Fira Code',monospace;">${escHtml(f.commit_sha.substring(0,8))}</span>`:''}
+          ${f.github_alert_url?`<a href="${escHtml(f.github_alert_url)}" target="_blank" title="View alert on GitHub" style="color:#475569;display:flex;align-items:center;" onmouseover="this.style.color='#00e5ff'" onmouseout="this.style.color='#475569'"><i data-lucide="external-link" style="width:14px;height:14px;"></i></a>`:''}
+        </div>
+      </div>
+    `).join('');
+
+    return `<div style="background:linear-gradient(145deg,#0f1b34,#080f1d);border:1px solid rgba(0,229,255,0.1);border-radius:14px;margin-bottom:16px;overflow:hidden;">
+      <div style="padding:14px 18px;border-bottom:1px solid rgba(255,255,255,0.05);display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:8px;">
+        <div style="display:flex;align-items:center;gap:14px;">
+          ${groupLabel}
+          ${authorHtml}
+        </div>
+        <span style="font-size:12px;color:#475569;background:rgba(255,255,255,0.04);padding:3px 10px;border-radius:20px;">${group.findings.length} alert${group.findings.length!==1?'s':''}</span>
+      </div>
+      <div style="padding:6px 4px;">${findingRows}</div>
+    </div>`;
+  }).join('');
+  lucide.createIcons();
+}
+
+async function syncGithubAlerts(){
+  const btn=document.getElementById('sync-alerts-btn');
+  btn.disabled=true;
+  btn.innerHTML='<div style="animation:spin 1s linear infinite;width:15px;height:15px;border:2px solid rgba(255,255,255,0.3);border-top-color:#00e5ff;border-radius:50%;"></div> Syncing...';
+  try{
+    const res=await fetch(`/api/v1/github/apps/${appId}/sync-alerts`,{method:'POST'});
+    if(!res.ok)throw new Error((await res.json()).detail||'Sync failed');
+    showToast('GitHub alerts sync started — refreshing in 5s…','success');
+    setTimeout(()=>loadGithubTab(),5000);
+  }catch(e){showToast(e.message,'error');}
+  finally{
+    btn.disabled=false;
+    btn.innerHTML='<i data-lucide="shield-check" style="width:15px;height:15px;"></i> Sync GitHub Alerts';
+    lucide.createIcons();
   }
 }
 

--- a/frontend/app-detail.html
+++ b/frontend/app-detail.html
@@ -855,10 +855,8 @@ async function loadGithubTab(){
   }
   el.innerHTML='<div style="text-align:center;padding:32px;"><div style="animation:spin 1s linear infinite;display:inline-block;width:24px;height:24px;border:2px solid rgba(255,255,255,0.1);border-top-color:#00e5ff;border-radius:50%;"></div></div>';
   try{
-    const res=await fetch(`/api/v1/findings?application_id=${appId}&page_size=500`);
-    if(!res.ok)throw new Error('Failed to load findings');
-    const data=await res.json();
-    const findings=(data.items||data||[]).filter(f=>f.github_alert_url||f.introduced_by||f.commit_sha);
+    const all=await fetchAllFindings(`/api/v1/applications/${appId}/findings`);
+    const findings=all.filter(f=>f.github_alert_url||f.introduced_by||f.commit_sha);
     renderGithubTab(findings);
   }catch(e){
     el.innerHTML=`<div style="text-align:center;padding:32px;color:#ef4444;">${e.message}</div>`;
@@ -954,6 +952,21 @@ async function syncGithubAlerts(){
   }
 }
 
+async function fetchAllFindings(baseUrl){
+  // Fetch all pages (API max page_size=100)
+  let page=1, items=[], pages=1;
+  do {
+    const sep=baseUrl.includes('?')?'&':'?';
+    const res=await fetch(`${baseUrl}${sep}page=${page}&page_size=100`);
+    if(!res.ok)break;
+    const d=await res.json();
+    items=items.concat(d.items||[]);
+    pages=d.pages||1;
+    page++;
+  } while(page<=pages);
+  return items;
+}
+
 async function loadPage(){
   if(!appId){
     document.getElementById('page-title').textContent='Application Not Found';
@@ -961,23 +974,14 @@ async function loadPage(){
     return;
   }
   try{
-    const [appRes,findingsRes]=await Promise.all([
-      fetch(`/api/v1/applications/${appId}`),
-      fetch(`/api/v1/applications/${appId}/findings`),
-    ]);
+    const appRes=await fetch(`/api/v1/applications/${appId}`);
     if(!appRes.ok)throw new Error('Application not found');
     appData=await appRes.json();
     renderAppInfo(appData);
     renderFindingStats({critical:appData.critical_count||0,high:appData.high_count||0,medium:appData.medium_count||0,low:appData.low_count||0});
 
-    if(findingsRes.ok){
-      const fd=await findingsRes.json();
-      allFindings=fd.items||fd||[];
-      applyFindingFilters();
-    } else {
-      allFindings=[];
-      renderFindingsTable([]);
-    }
+    allFindings=await fetchAllFindings(`/api/v1/applications/${appId}/findings`);
+    applyFindingFilters();
   }catch(e){
     document.getElementById('page-title').textContent='Error Loading App';
     showToast(e.message,'error');

--- a/frontend/app-detail.html
+++ b/frontend/app-detail.html
@@ -371,6 +371,11 @@ function renderAppInfo(app){
     <div style="margin-top:12px;font-size:14px;color:#475569;display:flex;align-items:center;justify-content:center;gap:6px;">
       <i data-lucide="clock" style="width:13px;height:13px;"></i> Last scan: ${timeAgo(app.last_scan_at)}
     </div>
+    ${app.last_github_sync_at ? `
+    <div style="margin-top:6px;font-size:13px;color:#475569;display:flex;align-items:center;justify-content:center;gap:6px;">
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" style="flex-shrink:0;"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+      GitHub sync: ${timeAgo(app.last_github_sync_at)}
+    </div>` : ''}
     <div style="display:flex;justify-content:center;gap:6px;margin-top:14px;flex-wrap:wrap;">
       <span style="background:rgba(239,68,68,0.12);color:#ef4444;border:1px solid rgba(239,68,68,0.25);padding:3px 10px;border-radius:6px;font-size:13px;font-weight:700;font-family:'Fira Code',monospace;">${app.critical_count||0}C</span>
       <span style="background:rgba(245,158,11,0.12);color:#f59e0b;border:1px solid rgba(245,158,11,0.25);padding:3px 10px;border-radius:6px;font-size:13px;font-weight:700;font-family:'Fira Code',monospace;">${app.high_count||0}H</span>

--- a/frontend/applications.html
+++ b/frontend/applications.html
@@ -352,8 +352,11 @@ function appRow(app) {
         <button onclick="location.href='/app-detail.html?id=${app.id}'" class="btn-secondary" style="padding:6px 10px;font-size:14px;margin-right:4px;" title="View details">
           <i data-lucide="eye" style="width:14px;height:14px;"></i>
         </button>
-        <button onclick="runScan(event,'${app.id}','${app.name||'app'}')" id="scan-btn-${app.id}" class="btn-secondary" style="padding:6px 10px;font-size:14px;" title="Run scan">
+        <button onclick="runScan(event,'${app.id}','${app.name||'app'}')" id="scan-btn-${app.id}" class="btn-secondary" style="padding:6px 10px;font-size:14px;margin-right:4px;" title="Run scan">
           <i data-lucide="play" style="width:14px;height:14px;color:#00e5ff;"></i>
+        </button>
+        <button onclick="deleteApp(event,'${app.id}',${JSON.stringify(app.name||'app').replace(/"/g,'&quot;')})" class="btn-secondary" style="padding:6px 10px;font-size:14px;" title="Remove application">
+          <i data-lucide="trash-2" style="width:14px;height:14px;color:#ef4444;"></i>
         </button>
       </td>
     </tr>
@@ -377,6 +380,21 @@ async function runScan(e, id, name) {
     btn.disabled = false;
     btn.innerHTML = '<i data-lucide="play" style="width:14px;height:14px;color:#00e5ff;"></i>';
     lucide.createIcons();
+  }
+}
+
+// ── Delete Application ─────────────────────────────────────────────────────────
+async function deleteApp(e, id, name) {
+  e.stopPropagation();
+  if (!confirm(`Remove "${name}" and all its scans and findings? This cannot be undone.`)) return;
+  try {
+    const res = await fetch(`/api/v1/applications/${id}`, { method: 'DELETE' });
+    if (!res.ok && res.status !== 204) throw new Error(`Server returned ${res.status}`);
+    allApps = allApps.filter(a => a.id !== id);
+    applyFilters();
+    showToast(`"${name}" removed`, 'success');
+  } catch(err) {
+    showToast(`Failed to remove application: ${err.message}`, 'error');
   }
 }
 

--- a/frontend/findings.html
+++ b/frontend/findings.html
@@ -397,6 +397,37 @@ function renderPanel(f) {
           <div style="font-size:14px;color:#94a3b8;">${timeAgo(f.first_seen_at)}</div>
         </div>
       </div>
+      ${(f.github_alert_url || f.commit_sha || f.introduced_by || f.pr_url) ? `
+      <div style="border:1px solid rgba(0,229,255,0.12);border-radius:10px;padding:16px;background:rgba(0,229,255,0.03);">
+        <div style="font-size:13px;font-weight:600;color:#00e5ff;text-transform:uppercase;letter-spacing:1px;margin-bottom:12px;display:flex;align-items:center;gap:8px;">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+          GitHub
+        </div>
+        <div style="display:flex;flex-direction:column;gap:10px;">
+          ${f.introduced_by ? `
+          <div style="display:flex;align-items:center;gap:10px;">
+            <img src="https://github.com/${eh(f.introduced_by)}.png?size=24" width="24" height="24" style="border-radius:50%;border:1px solid rgba(0,229,255,0.2);" onerror="this.style.display='none'">
+            <div>
+              <div style="font-size:11px;color:#475569;text-transform:uppercase;letter-spacing:0.5px;">Introduced by</div>
+              <a href="https://github.com/${eh(f.introduced_by)}" target="_blank" style="font-size:13px;color:#00e5ff;text-decoration:none;font-family:'Fira Code',monospace;" onmouseover="this.style.textDecoration='underline'" onmouseout="this.style.textDecoration='none'">@${eh(f.introduced_by)}</a>
+            </div>
+          </div>` : ''}
+          ${f.commit_sha ? `
+          <div>
+            <div style="font-size:11px;color:#475569;text-transform:uppercase;letter-spacing:0.5px;margin-bottom:2px;">Commit</div>
+            <a href="https://github.com/${eh(f.introduced_by||'')}" target="_blank" style="font-size:13px;color:#94a3b8;font-family:'Fira Code',monospace;text-decoration:none;" title="${eh(f.commit_sha)}">${eh(f.commit_sha.substring(0,8))}</a>
+          </div>` : ''}
+          ${f.pr_url ? `
+          <div>
+            <div style="font-size:11px;color:#475569;text-transform:uppercase;letter-spacing:0.5px;margin-bottom:2px;">Pull Request</div>
+            <a href="${eh(f.pr_url)}" target="_blank" style="font-size:13px;color:#00e5ff;text-decoration:none;" onmouseover="this.style.textDecoration='underline'" onmouseout="this.style.textDecoration='none'">PR #${f.pr_number || ''} ↗</a>
+          </div>` : ''}
+          ${f.github_alert_url ? `
+          <a href="${eh(f.github_alert_url)}" target="_blank" style="display:inline-flex;align-items:center;gap:6px;background:rgba(0,229,255,0.08);border:1px solid rgba(0,229,255,0.2);color:#00e5ff;padding:7px 14px;border-radius:8px;font-size:13px;font-weight:500;text-decoration:none;width:fit-content;" onmouseover="this.style.background='rgba(0,229,255,0.15)'" onmouseout="this.style.background='rgba(0,229,255,0.08)'">
+            View alert on GitHub ↗
+          </a>` : ''}
+        </div>
+      </div>` : ''}
       <div>
         <div style="font-size:13px;font-weight:600;color:#475569;text-transform:uppercase;letter-spacing:1px;margin-bottom:8px;">Status</div>
         <select id="panel-status-select" style="background:rgba(0,0,0,0.3);border:1px solid rgba(0,229,255,0.25);color:#f1f5f9;padding:8px 12px;border-radius:8px;font-size:14px;width:100%;cursor:pointer;" onchange="updateFindingStatus('${eh(f.id)}', this.value)">

--- a/frontend/repositories.html
+++ b/frontend/repositories.html
@@ -83,7 +83,7 @@
     </div>
 
     <!-- Idle (not yet loaded) -->
-    <div id="idle" style="text-align:center;padding:60px 20px;">
+    <div id="idle" style="display:none;text-align:center;padding:60px 20px;">
       <i data-lucide="refresh-cw" style="width:48px;height:48px;color:#475569;margin:0 auto 16px;display:block;"></i>
       <div style="font-size:19px;font-weight:600;color:#f1f5f9;margin-bottom:8px;">Repositories not loaded</div>
       <div style="color:#64748b;font-size:16px;max-width:400px;margin:0 auto;">Click <strong style="color:#00e5ff;">Refresh</strong> to fetch your GitHub repositories.</div>
@@ -360,7 +360,9 @@
         if (res.status === 400) {
           loading.style.display = 'none';
           noToken.style.display = 'block';
-          refreshIcon.style.animation = '';
+          lucide.createIcons();
+          const icon = document.getElementById('refresh-icon');
+          if (icon) icon.style.animation = '';
           return;
         }
         if (!res.ok) throw new Error(await res.text());
@@ -385,8 +387,10 @@
         grid.innerHTML = `<div style="grid-column:1/-1;text-align:center;padding:40px;color:#ef4444;">${escHtml(msg)}</div>`;
       } finally {
         loading.style.display = 'none';
-        refreshIcon.style.animation = '';
         lucide.createIcons();
+        // Re-query after lucide may have replaced the SVG element
+        const icon = document.getElementById('refresh-icon');
+        if (icon) icon.style.animation = '';
       }
     }
 
@@ -520,6 +524,7 @@
 
     applyTheme(localStorage.getItem('theme')||'dark');
     lucide.createIcons();
+    loadRepos();
   </script>
 </body>
 </html>

--- a/frontend/repositories.html
+++ b/frontend/repositories.html
@@ -82,6 +82,13 @@
       </div>
     </div>
 
+    <!-- Idle (not yet loaded) -->
+    <div id="idle" style="text-align:center;padding:60px 20px;">
+      <i data-lucide="refresh-cw" style="width:48px;height:48px;color:#475569;margin:0 auto 16px;display:block;"></i>
+      <div style="font-size:19px;font-weight:600;color:#f1f5f9;margin-bottom:8px;">Repositories not loaded</div>
+      <div style="color:#64748b;font-size:16px;max-width:400px;margin:0 auto;">Click <strong style="color:#00e5ff;">Refresh</strong> to fetch your GitHub repositories.</div>
+    </div>
+
     <!-- Loading -->
     <div id="loading" style="display:none;text-align:center;padding:60px 20px;">
       <div style="width:32px;height:32px;border:3px solid rgba(0,229,255,0.2);border-top-color:#00e5ff;border-radius:50%;animation:spin 0.8s linear infinite;margin:0 auto 16px;"></div>
@@ -334,9 +341,11 @@
       const grid = document.getElementById('repo-grid');
       const loading = document.getElementById('loading');
       const noToken = document.getElementById('no-token');
+      const idle = document.getElementById('idle');
       const refreshIcon = document.getElementById('refresh-icon');
 
       grid.innerHTML = '';
+      idle.style.display = 'none';
       loading.style.display = 'block';
       noToken.style.display = 'none';
       refreshIcon.style.animation = 'spin 0.8s linear infinite';
@@ -511,7 +520,6 @@
 
     applyTheme(localStorage.getItem('theme')||'dark');
     lucide.createIcons();
-    loadRepos();
   </script>
 </body>
 </html>

--- a/frontend/repositories.html
+++ b/frontend/repositories.html
@@ -33,6 +33,9 @@
         <p style="font-size:13px;color:#475569;margin:2px 0 0;font-family:'Fira Code',monospace;">// github.repositories · discovery</p>
       </div>
       <div id="header-user-slot" style="display:flex;align-items:center;gap:12px;">
+        <button class="btn-secondary" onclick="openPublicRepoModal()" style="font-size:14px;">
+          <i data-lucide="globe" style="width:15px;height:15px;"></i> Track Public Repo
+        </button>
         <button class="btn-primary" onclick="loadRepos()">
           <i data-lucide="refresh-cw" style="width:16px;height:16px;" id="refresh-icon"></i> Refresh
         </button>
@@ -119,9 +122,67 @@
     </div>
   </div>
 
+  <!-- Track Public Repo modal -->
+  <div id="public-repo-modal" class="modal-backdrop" style="display:none;" onclick="if(event.target===this)closePublicRepoModal()">
+    <div class="card" style="width:520px;max-width:95vw;padding:28px;position:relative;" onclick="event.stopPropagation()">
+      <button onclick="closePublicRepoModal()" style="position:absolute;top:16px;right:16px;background:none;border:none;color:#64748b;cursor:pointer;padding:4px;">
+        <i data-lucide="x" style="width:18px;height:18px;"></i>
+      </button>
+      <div style="display:flex;align-items:center;gap:10px;margin-bottom:20px;">
+        <div style="width:36px;height:36px;background:linear-gradient(135deg,rgba(0,229,255,0.15),rgba(99,102,241,0.15));border:1px solid rgba(0,229,255,0.2);border-radius:10px;display:flex;align-items:center;justify-content:center;">
+          <i data-lucide="globe" style="width:18px;height:18px;color:#00e5ff;"></i>
+        </div>
+        <div>
+          <div style="font-size:17px;font-weight:600;color:#f1f5f9;">Track Public Repo</div>
+          <div style="font-size:14px;color:#64748b;">Add any open source GitHub repository</div>
+        </div>
+      </div>
+
+      <!-- Step 1: URL input -->
+      <div id="public-step-1">
+        <div style="margin-bottom:16px;">
+          <label style="font-size:14px;color:#94a3b8;font-weight:500;display:block;margin-bottom:6px;">GitHub URL or org/repo</label>
+          <input type="text" id="public-repo-url" placeholder="e.g. https://github.com/org/repo  or  org/repo" class="dark-input" style="width:100%;" oninput="clearPublicLookupError()">
+          <div id="public-lookup-error" style="display:none;font-size:13px;color:#ef4444;margin-top:6px;"></div>
+        </div>
+        <div style="display:flex;gap:10px;">
+          <button class="btn-secondary" style="flex:1;justify-content:center;" onclick="closePublicRepoModal()">Cancel</button>
+          <button class="btn-primary" style="flex:1;justify-content:center;" id="public-lookup-btn" onclick="lookupPublicRepo()">
+            <i data-lucide="search" style="width:14px;height:14px;"></i> Look Up
+          </button>
+        </div>
+      </div>
+
+      <!-- Step 2: Confirm metadata -->
+      <div id="public-step-2" style="display:none;">
+        <div id="public-repo-meta" style="background:rgba(0,229,255,0.04);border:1px solid rgba(0,229,255,0.12);border-radius:10px;padding:14px;margin-bottom:16px;"></div>
+        <div style="display:flex;flex-direction:column;gap:12px;margin-bottom:16px;">
+          <div>
+            <label style="font-size:14px;color:#94a3b8;font-weight:500;display:block;margin-bottom:6px;">Team Name</label>
+            <input type="text" id="public-modal-team" placeholder="e.g. platform, security, backend" class="dark-input" style="width:100%;">
+          </div>
+          <div>
+            <label style="font-size:14px;color:#94a3b8;font-weight:500;display:block;margin-bottom:6px;">Scan Schedule</label>
+            <select id="public-modal-schedule" class="dark-select" style="width:100%;">
+              <option value="none">Manual only</option>
+              <option value="weekly">Weekly (every Sunday 2am UTC)</option>
+            </select>
+          </div>
+        </div>
+        <div style="display:flex;gap:10px;">
+          <button class="btn-secondary" style="flex:1;justify-content:center;" onclick="backToPublicStep1()">← Back</button>
+          <button class="btn-primary" style="flex:1;justify-content:center;" id="public-confirm-btn" onclick="confirmPublicAdd()">
+            <i data-lucide="plus" style="width:14px;height:14px;"></i> Add to Snitch
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <script>
     let allRepos = [];
     let pendingRepo = null;
+    let pendingPublicRepo = null;
 
     const LANG_COLORS = {
       Python:'#3776ab',JavaScript:'#f7df1e',TypeScript:'#3178c6',Go:'#00add8',
@@ -129,6 +190,127 @@
       C:'#555555','C#':'#178600',PHP:'#4f5d95',Kotlin:'#7f52ff',Swift:'#f05138',
     };
 
+    // ── Public repo modal ────────────────────────────────────────────────────
+    function openPublicRepoModal() {
+      document.getElementById('public-repo-url').value = '';
+      document.getElementById('public-lookup-error').style.display = 'none';
+      document.getElementById('public-step-1').style.display = 'block';
+      document.getElementById('public-step-2').style.display = 'none';
+      pendingPublicRepo = null;
+      document.getElementById('public-repo-modal').style.display = 'flex';
+      lucide.createIcons();
+    }
+
+    function closePublicRepoModal() {
+      document.getElementById('public-repo-modal').style.display = 'none';
+      pendingPublicRepo = null;
+    }
+
+    function backToPublicStep1() {
+      document.getElementById('public-step-2').style.display = 'none';
+      document.getElementById('public-step-1').style.display = 'block';
+    }
+
+    function clearPublicLookupError() {
+      document.getElementById('public-lookup-error').style.display = 'none';
+    }
+
+    function parseGithubInput(raw) {
+      // Accepts: https://github.com/org/repo, github.com/org/repo, or org/repo
+      const clean = raw.trim().replace(/\.git$/, '');
+      const match = clean.match(/(?:github\.com\/)?([^/\s]+)\/([^/\s]+)/);
+      return match ? { owner: match[1], repo: match[2] } : null;
+    }
+
+    async function lookupPublicRepo() {
+      const raw = document.getElementById('public-repo-url').value;
+      const parsed = parseGithubInput(raw);
+      const errEl = document.getElementById('public-lookup-error');
+
+      if (!parsed) {
+        errEl.textContent = 'Enter a valid GitHub URL or "org/repo" format.';
+        errEl.style.display = 'block';
+        return;
+      }
+
+      const btn = document.getElementById('public-lookup-btn');
+      btn.disabled = true;
+      btn.innerHTML = '<div style="width:14px;height:14px;border:2px solid rgba(255,255,255,0.3);border-top-color:white;border-radius:50%;animation:spin 0.8s linear infinite;display:inline-block;"></div> Looking up…';
+
+      try {
+        const res = await fetch(`/api/v1/github/repos/lookup?owner=${encodeURIComponent(parsed.owner)}&repo=${encodeURIComponent(parsed.repo)}`);
+        if (res.status === 404) throw new Error(`Repository ${parsed.owner}/${parsed.repo} not found.`);
+        if (!res.ok) throw new Error(await res.text());
+
+        pendingPublicRepo = await res.json();
+
+        // Populate metadata preview
+        const langColor = LANG_COLORS[pendingPublicRepo.language] || '#64748b';
+        document.getElementById('public-repo-meta').innerHTML = `
+          <div style="font-size:16px;font-weight:600;color:#f1f5f9;margin-bottom:6px;">${escHtml(pendingPublicRepo.full_name)}</div>
+          ${pendingPublicRepo.description ? `<div style="font-size:14px;color:#94a3b8;margin-bottom:8px;">${escHtml(pendingPublicRepo.description)}</div>` : ''}
+          <div style="display:flex;gap:10px;flex-wrap:wrap;">
+            ${pendingPublicRepo.language ? `<span style="display:flex;align-items:center;gap:5px;font-size:13px;color:#94a3b8;"><span style="width:8px;height:8px;border-radius:50%;background:${langColor};display:inline-block;"></span>${escHtml(pendingPublicRepo.language)}</span>` : ''}
+            ${pendingPublicRepo.private ? '<span style="font-size:13px;color:#a78bfa;">Private</span>' : '<span style="font-size:13px;color:#10b981;">Public</span>'}
+            ${pendingPublicRepo.archived ? '<span style="font-size:13px;color:#fbbf24;">Archived</span>' : ''}
+          </div>`;
+
+        document.getElementById('public-modal-team').value = pendingPublicRepo.github_org;
+        document.getElementById('public-modal-schedule').value = 'weekly';
+        document.getElementById('public-step-1').style.display = 'none';
+        document.getElementById('public-step-2').style.display = 'block';
+        lucide.createIcons();
+      } catch (e) {
+        errEl.textContent = e.message;
+        errEl.style.display = 'block';
+      } finally {
+        btn.disabled = false;
+        btn.innerHTML = '<i data-lucide="search" style="width:14px;height:14px;"></i> Look Up';
+        lucide.createIcons();
+      }
+    }
+
+    async function confirmPublicAdd() {
+      if (!pendingPublicRepo) return;
+      const btn = document.getElementById('public-confirm-btn');
+      btn.disabled = true;
+      btn.innerHTML = '<div style="width:14px;height:14px;border:2px solid rgba(255,255,255,0.3);border-top-color:white;border-radius:50%;animation:spin 0.8s linear infinite;display:inline-block;"></div> Adding…';
+
+      const team = document.getElementById('public-modal-team').value.trim() || pendingPublicRepo.github_org;
+      const schedule = document.getElementById('public-modal-schedule').value;
+
+      try {
+        const res = await fetch('/api/v1/applications', {
+          method: 'POST',
+          headers: {'Content-Type':'application/json'},
+          body: JSON.stringify({
+            name: pendingPublicRepo.github_repo,
+            description: pendingPublicRepo.description || '',
+            github_org: pendingPublicRepo.github_org,
+            github_repo: pendingPublicRepo.github_repo,
+            repo_url: pendingPublicRepo.repo_url,
+            team_name: team,
+            language: pendingPublicRepo.language || null,
+            scan_schedule: schedule,
+          }),
+        });
+        if (!res.ok) throw new Error(await res.text());
+        closePublicRepoModal();
+        await loadRepos();
+      } catch(e) {
+        alert('Failed to add repository: ' + e.message);
+        btn.disabled = false;
+        btn.innerHTML = '<i data-lucide="plus" style="width:14px;height:14px;"></i> Add to Snitch';
+        lucide.createIcons();
+      }
+    }
+
+    function escHtml(str) {
+      if (!str) return '';
+      return String(str).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
+    }
+
+    // ── Existing repo list ───────────────────────────────────────────────────
     async function loadRepos() {
       const grid = document.getElementById('repo-grid');
       const loading = document.getElementById('loading');

--- a/frontend/repositories.html
+++ b/frontend/repositories.html
@@ -434,9 +434,14 @@
         const privateBadge = r.private ? `<span style="background:rgba(139,92,246,0.1);color:#a78bfa;border:1px solid rgba(139,92,246,0.2);border-radius:6px;padding:2px 8px;font-size:13px;font-weight:500;">Private</span>` : '';
 
         const actionBtn = r.tracked
-          ? `<a href="/applications.html" class="btn-secondary" style="font-size:14px;padding:7px 12px;text-decoration:none;">
-               <i data-lucide="eye" style="width:13px;height:13px;"></i> View
-             </a>`
+          ? `<div style="display:flex;gap:8px;align-items:center;">
+               <a href="/applications.html" class="btn-secondary" style="font-size:14px;padding:7px 12px;text-decoration:none;">
+                 <i data-lucide="eye" style="width:13px;height:13px;"></i> View
+               </a>
+               <button class="btn-secondary" style="font-size:14px;padding:7px 12px;" onclick="syncAlerts('${r.application_id}')" title="Sync GitHub security alerts">
+                 <i data-lucide="shield" style="width:13px;height:13px;color:#00e5ff;"></i>
+               </button>
+             </div>`
           : `<button class="btn-primary" style="font-size:14px;padding:7px 14px;" onclick="openAddModal(${idx})">
                <i data-lucide="plus" style="width:13px;height:13px;"></i> Add to Snitch
              </button>`;
@@ -480,6 +485,17 @@
     function closeModal() {
       document.getElementById('add-modal').style.display = 'none';
       pendingRepo = null;
+    }
+
+    async function syncAlerts(appId) {
+      if (!appId) return;
+      try {
+        const res = await fetch(`/api/v1/github/apps/${appId}/sync-alerts`, { method: 'POST' });
+        if (!res.ok) throw new Error((await res.json()).detail || 'Sync failed');
+        showToast('GitHub security sync queued — findings will appear shortly', 'success');
+      } catch(err) {
+        showToast(`Sync failed: ${err.message}`, 'error');
+      }
     }
 
     async function confirmAdd() {

--- a/frontend/repositories.html
+++ b/frontend/repositories.html
@@ -11,14 +11,19 @@
   <style>
     * { box-sizing: border-box; }
     @keyframes fadeInUp { from{transform:translateY(20px);opacity:0} to{transform:translateY(0);opacity:1} }
+    @keyframes fadeInDown { from{transform:translateY(-20px);opacity:0} to{transform:translateY(0);opacity:1} }
     @keyframes spin { to{transform:rotate(360deg)} }
     .card-hover:hover { border-color:rgba(0,229,255,0.3) !important; transform:translateY(-2px); transition:all 0.3s; }
     .card { background:linear-gradient(145deg,#0f1b34 0%,#080f1d 100%);border:1px solid rgba(0,229,255,0.14);border-radius:16px;box-shadow:0 4px 32px rgba(0,0,0,.55),inset 0 1px 0 rgba(0,229,255,.06); }
     .dark-select option { background:#0d1117; }
     .modal-backdrop { position:fixed;inset:0;background:rgba(0,0,0,0.75);backdrop-filter:blur(10px);z-index:200;display:flex;align-items:center;justify-content:center; }
+    #toast { position:fixed;top:20px;left:50%;transform:translateX(-50%);z-index:999;display:none;animation:fadeInDown 0.3s ease; }
   </style>
 </head>
 <body style="font-family:var(--font-body,'Fira Sans',system-ui,sans-serif);background:var(--bg-page,#0a0e1a);color:var(--text-primary,#f1f5f9);margin:0;padding:0;min-height:100vh;">
+
+  <!-- Success toast -->
+  <div id="toast"></div>
 
   <!-- Sidebar -->
   <div id="sidebar-mount"></div>
@@ -295,8 +300,10 @@
           }),
         });
         if (!res.ok) throw new Error(await res.text());
+        const repoName = pendingPublicRepo.github_repo;
         closePublicRepoModal();
-        await loadRepos();
+        showToast(`<i data-lucide="check-circle" style="width:16px;height:16px;"></i> <strong>${escHtml(repoName)}</strong> added — <a href="/applications.html" style="color:inherit;text-decoration:underline;">View in Applications →</a>`);
+        lucide.createIcons();
       } catch(e) {
         alert('Failed to add repository: ' + e.message);
         btn.disabled = false;
@@ -308,6 +315,18 @@
     function escHtml(str) {
       if (!str) return '';
       return String(str).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
+    }
+
+    let _toastTimer = null;
+    function showToast(html, type = 'success') {
+      const el = document.getElementById('toast');
+      const bg = type === 'success' ? 'rgba(16,185,129,0.15)' : 'rgba(239,68,68,0.15)';
+      const border = type === 'success' ? 'rgba(16,185,129,0.35)' : 'rgba(239,68,68,0.35)';
+      const color = type === 'success' ? '#10b981' : '#ef4444';
+      el.innerHTML = `<div style="background:${bg};border:1px solid ${border};color:${color};border-radius:10px;padding:12px 20px;font-size:14px;font-weight:500;display:flex;align-items:center;gap:10px;box-shadow:0 4px 24px rgba(0,0,0,0.6);white-space:nowrap;">${html}</div>`;
+      el.style.display = 'block';
+      if (_toastTimer) clearTimeout(_toastTimer);
+      _toastTimer = setTimeout(() => { el.style.display = 'none'; }, 5000);
     }
 
     // ── Existing repo list ───────────────────────────────────────────────────
@@ -322,9 +341,13 @@
       noToken.style.display = 'none';
       refreshIcon.style.animation = 'spin 0.8s linear infinite';
 
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 30000);
+
       try {
         const showArchived = document.getElementById('show-archived').checked;
-        const res = await fetch(`/api/v1/github/repos?include_archived=${showArchived}`);
+        const res = await fetch(`/api/v1/github/repos?include_archived=${showArchived}`, { signal: controller.signal });
+        clearTimeout(timeoutId);
         if (res.status === 400) {
           loading.style.display = 'none';
           noToken.style.display = 'block';
@@ -346,7 +369,11 @@
 
         renderRepos();
       } catch (e) {
-        grid.innerHTML = `<div style="grid-column:1/-1;text-align:center;padding:40px;color:#ef4444;">${e.message}</div>`;
+        clearTimeout(timeoutId);
+        const msg = e.name === 'AbortError'
+          ? 'GitHub API timed out (30s). Check your GITHUB_TOKEN or try again.'
+          : e.message;
+        grid.innerHTML = `<div style="grid-column:1/-1;text-align:center;padding:40px;color:#ef4444;">${escHtml(msg)}</div>`;
       } finally {
         loading.style.display = 'none';
         refreshIcon.style.animation = '';
@@ -467,8 +494,13 @@
           }),
         });
         if (!res.ok) throw new Error(await res.text());
+        const added = pendingRepo;
         closeModal();
-        await loadRepos();
+        // Mark the card as tracked without re-fetching all repos
+        allRepos = allRepos.map(r => r.full_name === added.full_name ? {...r, tracked: true} : r);
+        renderRepos();
+        showToast(`<i data-lucide="check-circle" style="width:16px;height:16px;"></i> <strong>${escHtml(added.github_repo)}</strong> added — <a href="/applications.html" style="color:inherit;text-decoration:underline;">View in Applications →</a>`);
+        lucide.createIcons();
       } catch(e) {
         alert('Failed to add repository: ' + e.message);
         btn.disabled = false;


### PR DESCRIPTION
## Problem

Snitch's Global Findings Hub was showing duplicate findings with both `SEMGREP` and `SEMGREP_OSS` scanner badges for the same issues.

**Root cause:** The `semgrep.yml` workflow was changed at some point from `semgrep/semgrep-action@v1` (SARIF tool name: "Semgrep") to running the CLI directly via `pip install semgrep; semgrep scan` (SARIF tool name: "Semgrep OSS"). GitHub Code Scanning retains historical results from both tool names, and Snitch's GHAS poller ingests them as separate scanners since it derives the scanner value from the tool name.

## Changes

### `.github/workflows/semgrep.yml`
Reverted to `semgrep/semgrep-action@v1` (as documented in CLAUDE.md). This restores a consistent SARIF tool name of "Semgrep".

### `backend/app/services/github_service.py`
Added normalization in the GHAS poller: `semgrep_oss → semgrep`. This is a defensive fix so any remaining historical "Semgrep OSS" alerts are unified with "Semgrep" alerts in Snitch, preventing duplicate findings during the transition period.

## Testing
- All 155 backend tests pass