### PR TITLE
feat: restructure GitHub integration — commits, PRs, security sub-tabs per app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,9 @@ The sidebar is a shared JS component defined in `frontend/static/js/sidebar.js`.
 
 The header user widget is a shared JS component defined in `frontend/static/js/header.js`. Each HTML page includes `<script src="/static/js/header.js"></script>` after the sidebar script and adds `id="header-user-slot"` to the right-side container inside `<header>`. The script injects a circular user avatar button with a dropdown (Profile link + disabled Logout placeholder) into that slot. Do not duplicate the widget HTML across pages; edit `header.js` for any user-menu changes.
 
-The sidebar nav is structured into four sections: **Overview** (Dashboard, Applications, Findings, Threat Intel, Compliance, Reports, Secrets), **Config** (Policies, Rules), **Admin** (Settings, Repositories, Service Accounts), **Help** (Documentation `/help.html`, About `/about.html`, API Docs `/docs`). The Profile link has been removed from the sidebar — it is only accessible via the header user widget dropdown. Nav items that open external links set `external: true` in NAV_SECTIONS and are rendered with a target="_blank" and an external-link icon.
+The sidebar nav is structured into four sections: **Overview** (Dashboard, Applications, Findings, Reports, Secrets, Threat Intel, Compliance), **Config** (Policies, Rules), **Admin** (Settings, Integrations, Repositories, Service Accounts), **Help** (Documentation `/help.html`, About `/about.html`, API Docs `/docs`). The Profile link has been removed from the sidebar — it is only accessible via the header user widget dropdown. Nav items that open external links set `external: true` in NAV_SECTIONS and are rendered with a target="_blank" and an external-link icon. The sidebar `<aside>` uses `height:100vh;overflow:hidden` so the `<nav>` (which has `overflow-y:auto`) scrolls within the fixed viewport height.
+
+The application detail page (`/app-detail.html`) has four main tabs: **Findings**, **Scan History**, **Remediations**, and **GitHub**. The GitHub tab has three sub-tabs rendered by `switchSubTab()`: **Commits** (calls `GET /api/v1/github/apps/{id}/commits`, renders commit history with avatar/sha/message), **Pull Requests** (calls `GET /api/v1/github/apps/{id}/pr-reviews`, shows PR cards with collapsible security findings), and **Security** (GHAS alerts via "Sync GitHub Alerts" button). The GitHub repo link appears as a small SVG icon button (34×34px, absolute-positioned top-right of the app info card) — no text, hover shows org/repo tooltip.
 
 The `/settings.html` page is the admin configuration page for platform integrations (GitHub token, Anthropic API key), scan defaults, and read-only system info. It stores token presence flags in `localStorage` only — raw secrets are never persisted client-side.
 
@@ -202,7 +204,11 @@ Each finding includes: `commit_sha` (SHA that introduced it), `introduced_by` (G
 
 Dedup key: `(application_id, scanner, github_alert_number)`. If a token lacks scope for an alert type, that type is silently skipped. Commit author is fetched via `GET /repos/{owner}/{repo}/commits/{sha}` — not fetched for Dependabot (no commit SHA available).
 
+**Cross-scanner deduplication:** When a new GHAS finding is about to be inserted, `_has_native_duplicate()` in `github_tasks.py` checks whether a native scanner (semgrep, grype, trivy, etc.) already tracks the same vulnerability. For Dependabot: matches on `cve_id` + `package_name`; for code-scanning SAST: matches on `rule_id` + `file_path`. Secret-scanning alerts are never deduplicated. If a null field prevents matching, the GHAS finding is allowed through (conservative). `_GHAS_SCANNERS = frozenset({"codeql", "github_secret_scanning", "dependabot"})` is the exclusion set for native-scanner queries.
+
 `POST /api/v1/github/apps/{app_id}/sync-alerts` triggers an immediate sync for one app (returns task ID). The beat schedule fires every 5 minutes for all tracked apps. Last sync time stored in `Application.last_github_sync_at`.
+
+`GET /api/v1/github/apps/{app_id}/commits?limit=20` returns recent commit history from `GET /repos/{owner}/{repo}/commits`. Response: `CommitsResponse` with `total_commits`, `commits[]` (sha, short_sha, message, author_name, author_login, author_avatar, date, commit_url). Implemented in `fetch_recent_commits()` in `github_service.py`.
 
 New Finding fields (migration 010): `commit_sha`, `introduced_by`, `pr_number`, `pr_url`, `github_alert_url`, `github_alert_number`. New Application field: `last_github_sync_at`.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 | 🔑 **Secrets Detection** | Gitleaks integration with configurable custom regex patterns per organisation |
 | 🤖 **AI Remediation** | Claude-powered "Plan Remediation" generates fix instructions, then creates a GitHub PR |
 | 📈 **90-Day Trends** | Management reporting with vulnerability trends, team leaderboard, and MTTR |
-| 🔗 **GitHub Integration** | Sync code-scanning alerts from GitHub Security; auto-create branches & PRs |
+| 🔗 **GitHub Integration** | Commit history, PR reviews, and GHAS security alerts — all scoped per-application in the GitHub tab (Commits / Pull Requests / Security sub-tabs) |
 | 🚦 **Policy Engine** | Define pass/fail gates by severity, scan type, and rule — evaluated on every scan |
 | 🔑 **Service Accounts** | Machine identities for CI/CD pipelines — Bearer token auth (`snitch_<32chars>`) for the push endpoint; token shown once, SHA-256 hash stored |
 | 🌐 **REST API** | Full OpenAPI/Swagger docs at `/docs` |

--- a/backend/app/api/v1/github.py
+++ b/backend/app/api/v1/github.py
@@ -11,7 +11,7 @@ from app.core.config import settings
 from app.db.session import get_db
 from app.models.application import Application
 from app.models.finding import Finding
-from app.services.github_service import fetch_pull_requests, list_accessible_repos, lookup_public_repo
+from app.services.github_service import fetch_pull_requests, fetch_recent_commits, list_accessible_repos, lookup_public_repo
 
 router = APIRouter(prefix="/github", tags=["github"])
 
@@ -239,4 +239,51 @@ async def get_pr_reviews(
         github_repo=app.github_repo,
         total_prs=len(prs),
         prs=prs,
+    )
+
+
+class CommitInfo(BaseModel):
+    sha: Optional[str]
+    short_sha: Optional[str]
+    message: Optional[str]
+    author_name: Optional[str]
+    author_login: Optional[str]
+    author_avatar: Optional[str]
+    date: Optional[str]
+    commit_url: Optional[str]
+
+
+class CommitsResponse(BaseModel):
+    application_id: uuid.UUID
+    application_name: str
+    github_org: str
+    github_repo: str
+    total_commits: int
+    commits: List[CommitInfo]
+
+
+@router.get("/apps/{app_id}/commits", response_model=CommitsResponse)
+async def get_recent_commits(
+    app_id: uuid.UUID,
+    limit: int = Query(20, ge=1, le=100, description="Number of recent commits to fetch"),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return recent commit history for an application's GitHub repository."""
+    result = await db.execute(select(Application).where(Application.id == app_id))
+    app = result.scalar_one_or_none()
+    if not app:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if not app.github_org or not app.github_repo:
+        raise HTTPException(status_code=400, detail="Application has no GitHub repository configured")
+
+    token = settings.GITHUB_TOKEN or None
+    commits = await fetch_recent_commits(app.github_org, app.github_repo, token, limit=limit)
+
+    return CommitsResponse(
+        application_id=app.id,
+        application_name=app.name,
+        github_org=app.github_org,
+        github_repo=app.github_repo,
+        total_commits=len(commits),
+        commits=[CommitInfo(**c) for c in commits],
     )

--- a/backend/app/services/github_service.py
+++ b/backend/app/services/github_service.py
@@ -269,6 +269,43 @@ async def fetch_pull_requests(owner: str, repo: str, token: str | None, limit: i
     return prs[:limit]
 
 
+async def fetch_recent_commits(owner: str, repo: str, token: str | None, limit: int = 20) -> list[dict]:
+    """Fetch recent commits for a repository from the GitHub API."""
+    headers = _gh_headers(token)
+    async with httpx.AsyncClient(headers=headers, timeout=30) as client:
+        try:
+            r = await client.get(
+                f"{_GH_API}/repos/{owner}/{repo}/commits",
+                params={"per_page": min(limit, 100)},
+            )
+            if r.status_code in (403, 404):
+                logger.debug("Commits not available for %s/%s: %s", owner, repo, r.status_code)
+                return []
+            r.raise_for_status()
+            commits = []
+            for c in r.json():
+                commit_data = c.get("commit") or {}
+                author_data = commit_data.get("author") or {}
+                gh_author = c.get("author") or {}
+                sha = c.get("sha") or ""
+                commits.append({
+                    "sha": sha,
+                    "short_sha": sha[:8],
+                    "message": (commit_data.get("message") or "").split("\n")[0],
+                    "author_name": author_data.get("name"),
+                    "author_login": gh_author.get("login"),
+                    "author_avatar": gh_author.get("avatar_url"),
+                    "date": author_data.get("date"),
+                    "commit_url": c.get("html_url"),
+                })
+            return commits
+        except httpx.HTTPStatusError as e:
+            logger.warning("Commits error for %s/%s: %s", owner, repo, e)
+        except Exception as e:
+            logger.warning("Unexpected error fetching commits for %s/%s: %s", owner, repo, e)
+    return []
+
+
 async def fetch_github_security_alerts(owner: str, repo: str, token: str | None) -> list[dict]:
     """
     Fetch code-scanning, dependabot, and secret-scanning alerts for a repo.

--- a/backend/app/worker/github_tasks.py
+++ b/backend/app/worker/github_tasks.py
@@ -8,7 +8,7 @@ import logging
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import select
+from sqlalchemy import and_, select
 
 from app.core.config import settings
 from app.models.application import Application
@@ -87,6 +87,54 @@ def poll_github_security_task(self, app_id: str | None = None):
         db.close()
 
 
+_GHAS_SCANNERS = frozenset({"codeql", "github_secret_scanning", "dependabot"})
+
+
+def _has_native_duplicate(db, app_id, finding: dict) -> bool:
+    """Return True if a native (non-GHAS) scanner already tracks an equivalent finding."""
+    scanner = finding.get("scanner", "")
+    finding_type = finding.get("finding_type", "")
+
+    if scanner == "github_secret_scanning":
+        return False
+
+    if scanner == "dependabot":
+        cve_id = finding.get("cve_id")
+        package_name = finding.get("package_name")
+        if not cve_id or not package_name:
+            return False
+        existing = db.execute(
+            select(Finding).where(
+                and_(
+                    Finding.application_id == app_id,
+                    Finding.cve_id == cve_id,
+                    Finding.package_name == package_name,
+                    Finding.scanner.notin_(_GHAS_SCANNERS),
+                )
+            )
+        ).scalar_one_or_none()
+        return existing is not None
+
+    if finding_type == "sast":
+        rule_id = finding.get("rule_id")
+        file_path = finding.get("file_path")
+        if not rule_id or not file_path:
+            return False
+        existing = db.execute(
+            select(Finding).where(
+                and_(
+                    Finding.application_id == app_id,
+                    Finding.rule_id == rule_id,
+                    Finding.file_path == file_path,
+                    Finding.scanner.notin_(_GHAS_SCANNERS),
+                )
+            )
+        ).scalar_one_or_none()
+        return existing is not None
+
+    return False
+
+
 def _upsert_ghas_findings(db, app: Application, alert_findings: list[dict]) -> tuple[int, int]:
     """
     Upsert GHAS findings for an application.
@@ -125,6 +173,13 @@ def _upsert_ghas_findings(db, app: Application, alert_findings: list[dict]) -> t
             existing.last_seen_at = now
             updated += 1
         else:
+            if _has_native_duplicate(db, app.id, fd):
+                logger.debug(
+                    "Skipping GHAS finding — native duplicate exists: scanner=%s title=%s",
+                    scanner, fd.get("title"),
+                )
+                continue
+
             finding = Finding(
                 id=uuid.uuid4(),
                 application_id=app.id,

--- a/backend/app/worker/github_tasks.py
+++ b/backend/app/worker/github_tasks.py
@@ -87,13 +87,15 @@ def poll_github_security_task(self, app_id: str | None = None):
         db.close()
 
 
-_GHAS_SCANNERS = frozenset({"codeql", "github_secret_scanning", "dependabot"})
-
-
 def _has_native_duplicate(db, app_id, finding: dict) -> bool:
-    """Return True if a native (non-GHAS) scanner already tracks an equivalent finding."""
+    """Return True if a native (non-GHAS) scanner already tracks an equivalent finding.
+
+    Uses github_alert_number IS NULL as the native-finding discriminator — all GHAS
+    findings have a non-null alert number; native scanner findings never do.
+    Uses .scalars().first() to safely handle multiple matching rows.
+    """
     scanner = finding.get("scanner", "")
-    finding_type = finding.get("finding_type", "")
+    finding_type = (finding.get("finding_type") or "").lower()
 
     if scanner == "github_secret_scanning":
         return False
@@ -109,10 +111,10 @@ def _has_native_duplicate(db, app_id, finding: dict) -> bool:
                     Finding.application_id == app_id,
                     Finding.cve_id == cve_id,
                     Finding.package_name == package_name,
-                    Finding.scanner.notin_(_GHAS_SCANNERS),
+                    Finding.github_alert_number.is_(None),
                 )
             )
-        ).scalar_one_or_none()
+        ).scalars().first()
         return existing is not None
 
     if finding_type == "sast":
@@ -126,10 +128,10 @@ def _has_native_duplicate(db, app_id, finding: dict) -> bool:
                     Finding.application_id == app_id,
                     Finding.rule_id == rule_id,
                     Finding.file_path == file_path,
-                    Finding.scanner.notin_(_GHAS_SCANNERS),
+                    Finding.github_alert_number.is_(None),
                 )
             )
-        ).scalar_one_or_none()
+        ).scalars().first()
         return existing is not None
 
     return False

--- a/backend/tests/test_github.py
+++ b/backend/tests/test_github.py
@@ -408,3 +408,110 @@ async def test_pr_reviews_empty_when_no_prs(client: AsyncClient):
     data = resp.json()
     assert data["total_prs"] == 0
     assert data["prs"] == []
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/github/apps/{app_id}/commits endpoint tests
+# ---------------------------------------------------------------------------
+
+_MOCK_COMMIT_LIST = [
+    {
+        "sha": "abc123def456abc1",
+        "short_sha": "abc123de",
+        "message": "Fix authentication bug in token refresh",
+        "author_name": "Alice Smith",
+        "author_login": "alice",
+        "author_avatar": "https://avatars.githubusercontent.com/u/1?v=4",
+        "date": "2024-03-02T10:00:00Z",
+        "commit_url": "https://github.com/acme/api/commit/abc123def456abc1",
+    },
+    {
+        "sha": "deadbeef12345678",
+        "short_sha": "deadbeef",
+        "message": "Update dependency versions",
+        "author_name": "Bob",
+        "author_login": "bob",
+        "author_avatar": None,
+        "date": "2024-03-01T08:00:00Z",
+        "commit_url": "https://github.com/acme/api/commit/deadbeef12345678",
+    },
+]
+
+
+@pytest.mark.asyncio
+async def test_commits_app_not_found(client: AsyncClient):
+    import uuid
+    fake_id = str(uuid.uuid4())
+    resp = await client.get(f"/api/v1/github/apps/{fake_id}/commits")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_commits_no_github_repo(client: AsyncClient):
+    create_resp = await client.post("/api/v1/applications", json={
+        "name": "no-repo-commits",
+        "github_org": "",
+        "github_repo": "",
+        "repo_url": "https://example.com",
+        "team_name": "Backend",
+    })
+    assert create_resp.status_code == 201
+    app_id = create_resp.json()["id"]
+
+    resp = await client.get(f"/api/v1/github/apps/{app_id}/commits")
+    assert resp.status_code == 400
+    assert "GitHub repository" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_commits_returns_list(client: AsyncClient):
+    create_resp = await client.post("/api/v1/applications", json={
+        "name": "commits-test-app",
+        "github_org": "acme",
+        "github_repo": "api",
+        "repo_url": "https://github.com/acme/api",
+        "team_name": "Eng",
+    })
+    assert create_resp.status_code == 201
+    app_id = create_resp.json()["id"]
+
+    with patch(
+        "app.api.v1.github.fetch_recent_commits",
+        new_callable=AsyncMock,
+        return_value=_MOCK_COMMIT_LIST,
+    ):
+        resp = await client.get(f"/api/v1/github/apps/{app_id}/commits")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["github_org"] == "acme"
+    assert data["github_repo"] == "api"
+    assert data["total_commits"] == 2
+    assert data["commits"][0]["message"] == "Fix authentication bug in token refresh"
+    assert data["commits"][0]["author_login"] == "alice"
+    assert data["commits"][0]["short_sha"] == "abc123de"
+
+
+@pytest.mark.asyncio
+async def test_commits_empty_when_no_commits(client: AsyncClient):
+    create_resp = await client.post("/api/v1/applications", json={
+        "name": "empty-commits-app",
+        "github_org": "acme",
+        "github_repo": "quiet",
+        "repo_url": "https://github.com/acme/quiet",
+        "team_name": "Infra",
+    })
+    assert create_resp.status_code == 201
+    app_id = create_resp.json()["id"]
+
+    with patch(
+        "app.api.v1.github.fetch_recent_commits",
+        new_callable=AsyncMock,
+        return_value=[],
+    ):
+        resp = await client.get(f"/api/v1/github/apps/{app_id}/commits")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_commits"] == 0
+    assert data["commits"] == []

--- a/frontend/app-detail.html
+++ b/frontend/app-detail.html
@@ -433,6 +433,7 @@ function renderAppInfo(app){
   document.getElementById('app-info-card').innerHTML = `
     <div style="position:relative;">
     ${repoUrl ? `<a href="${repoUrl}" target="_blank" rel="noopener noreferrer"
+         aria-label="View ${escHtml(app.github_org)}/${escHtml(app.github_repo)} on GitHub"
          style="position:absolute;top:0;right:0;width:34px;height:34px;background:rgba(0,0,0,0.3);border:1px solid rgba(255,255,255,0.1);border-radius:8px;display:flex;align-items:center;justify-content:center;color:#94a3b8;text-decoration:none;transition:all 0.2s;z-index:1;"
          title="${escHtml(app.github_org)}/${escHtml(app.github_repo)} — View on GitHub"
          onmouseover="this.style.borderColor='rgba(0,229,255,0.4)';this.style.color='#00e5ff';this.style.background='rgba(0,229,255,0.1)'"
@@ -917,7 +918,7 @@ function renderCommitsSubTab(commits){
         <div style="font-size:14px;font-weight:500;color:#e2e8f0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;" title="${escHtml(c.message)}">${escHtml(c.message||'(no message)')}</div>
         <div style="font-size:12px;color:#475569;margin-top:2px;display:flex;align-items:center;gap:8px;">
           ${c.author_login
-            ?`<a href="https://github.com/${escHtml(c.author_login)}" target="_blank" style="color:#94a3b8;text-decoration:none;" onmouseover="this.style.color='#00e5ff'" onmouseout="this.style.color='#94a3b8'">@${escHtml(c.author_login)}</a>`
+            ?`<a href="https://github.com/${escHtml(c.author_login)}" target="_blank" rel="noopener noreferrer" style="color:#94a3b8;text-decoration:none;" onmouseover="this.style.color='#00e5ff'" onmouseout="this.style.color='#94a3b8'">@${escHtml(c.author_login)}</a>`
             :`<span>${escHtml(c.author_name||'Unknown')}</span>`
           }
           <span style="color:#334155;">·</span>
@@ -926,7 +927,7 @@ function renderCommitsSubTab(commits){
       </div>
       <div style="display:flex;align-items:center;gap:8px;flex-shrink:0;">
         <span style="font-size:12px;font-family:'Fira Code',monospace;color:#475569;background:rgba(0,0,0,0.3);padding:2px 8px;border-radius:4px;">${escHtml(c.short_sha||'')}</span>
-        ${c.commit_url?`<a href="${escHtml(c.commit_url)}" target="_blank" style="color:#475569;display:flex;align-items:center;" title="View on GitHub" onmouseover="this.style.color='#00e5ff'" onmouseout="this.style.color='#475569'"><i data-lucide="external-link" style="width:13px;height:13px;"></i></a>`:''}
+        ${c.commit_url?`<a href="${escHtml(c.commit_url)}" target="_blank" rel="noopener noreferrer" style="color:#475569;display:flex;align-items:center;" title="View on GitHub" onmouseover="this.style.color='#00e5ff'" onmouseout="this.style.color='#475569'"><i data-lucide="external-link" style="width:13px;height:13px;"></i></a>`:''}
       </div>
     </div>
   `).join('')}</div>`;

--- a/frontend/app-detail.html
+++ b/frontend/app-detail.html
@@ -31,6 +31,32 @@
     .status-dropdown { position:relative;display:inline-block; }
     .status-menu { display:none;position:absolute;right:0;top:100%;background:#0d1117;border:1px solid rgba(255,255,255,0.12);border-radius:10px;padding:4px;z-index:50;min-width:160px;box-shadow:0 8px 32px rgba(0,0,0,0.5); }
     .status-menu.open { display:block; }
+    .subtab-btn { padding:7px 16px;border-radius:6px;font-size:14px;font-weight:500;cursor:pointer;border:none;transition:all 0.2s;background:transparent;color:#64748b; }
+    .subtab-btn.active { background:rgba(0,229,255,0.1);color:#00e5ff;border:1px solid rgba(0,229,255,0.18); }
+    .subtab-btn:hover:not(.active) { background:rgba(255,255,255,0.04);color:#94a3b8; }
+    .pr-card { background:linear-gradient(145deg,#0f1b34,#080f1d);border:1px solid rgba(0,229,255,0.12);border-radius:12px;margin-bottom:16px;overflow:hidden;transition:border-color 0.2s; }
+    .pr-card:hover { border-color:rgba(0,229,255,0.3); }
+    .pr-header { padding:18px 24px;display:flex;align-items:flex-start;gap:16px;cursor:pointer;user-select:none; }
+    .pr-header:hover { background:rgba(0,229,255,0.03); }
+    .pr-state-badge { display:inline-flex;align-items:center;gap:5px;padding:4px 10px;border-radius:20px;font-size:12px;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;flex-shrink:0; }
+    .pr-state-open   { background:rgba(34,197,94,0.15);color:#4ade80;border:1px solid rgba(34,197,94,0.3); }
+    .pr-state-merged { background:rgba(168,85,247,0.15);color:#c084fc;border:1px solid rgba(168,85,247,0.3); }
+    .pr-state-closed { background:rgba(148,163,184,0.15);color:#94a3b8;border:1px solid rgba(148,163,184,0.3); }
+    .pr-state-draft  { background:rgba(100,116,139,0.15);color:#64748b;border:1px solid rgba(100,116,139,0.3); }
+    .findings-panel { border-top:1px solid rgba(0,229,255,0.08);padding:16px 24px 20px;display:none; }
+    .findings-panel.open { display:block; }
+    .finding-row { display:flex;align-items:center;gap:12px;padding:10px 12px;border-radius:8px;margin-bottom:6px;background:rgba(0,0,0,0.15);border:1px solid rgba(255,255,255,0.04);transition:background 0.15s; }
+    .finding-row:hover { background:rgba(0,229,255,0.04); }
+    .finding-row a { color:#00e5ff;text-decoration:none; }
+    .finding-row a:hover { text-decoration:underline; }
+    .count-pill { display:inline-flex;align-items:center;gap:5px;padding:3px 9px;border-radius:20px;font-size:12px;font-weight:700;font-family:'Fira Code',monospace; }
+    .count-pill-danger  { background:rgba(239,68,68,0.15);color:#f87171;border:1px solid rgba(239,68,68,0.3); }
+    .count-pill-success { background:rgba(16,185,129,0.15);color:#34d399;border:1px solid rgba(16,185,129,0.3); }
+    .count-pill-neutral { background:rgba(148,163,184,0.12);color:#94a3b8;border:1px solid rgba(148,163,184,0.2); }
+    .chevron-icon { transition:transform 0.2s;flex-shrink:0; }
+    .chevron-icon.rotated { transform:rotate(180deg); }
+    .section-label { font-size:11px;font-weight:700;letter-spacing:1.5px;text-transform:uppercase;color:#475569;font-family:'Fira Code',monospace;margin-bottom:8px;margin-top:14px;padding-left:4px; }
+    .section-label:first-child { margin-top:0; }
   </style>
 </head>
 <body style="font-family:var(--font-body,'Fira Sans',system-ui,sans-serif);background:var(--bg-page,#0a0e1a);color:var(--text-primary,#f1f5f9);margin:0;padding:0;min-height:100vh;">
@@ -115,7 +141,7 @@
             <i data-lucide="wrench" style="width:15px;height:15px;display:inline;vertical-align:middle;margin-right:6px;"></i>Remediations
           </button>
           <button class="tab-btn" id="tab-github" onclick="switchTab('github')">
-            <i data-lucide="github" style="width:15px;height:15px;display:inline;vertical-align:middle;margin-right:6px;"></i>GitHub Security
+            <i data-lucide="github" style="width:15px;height:15px;display:inline;vertical-align:middle;margin-right:6px;"></i>GitHub
           </button>
         </div>
 
@@ -176,18 +202,84 @@
           <div id="remediations-grid"><div style="text-align:center;padding:32px;"><div style="animation:spin 1s linear infinite;display:inline-block;width:24px;height:24px;border:2px solid rgba(255,255,255,0.1);border-top-color:#00e5ff;border-radius:50%;"></div></div></div>
         </div>
 
-        <!-- GitHub Security Tab -->
+        <!-- GitHub Tab (Commits / Pull Requests / Security sub-tabs) -->
         <div id="pane-github" style="display:none;">
-          <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:20px;flex-wrap:wrap;gap:12px;">
-            <div>
-              <div style="font-size:16px;font-weight:600;color:#f1f5f9;">GitHub Advanced Security Alerts</div>
-              <div id="github-sync-info" style="font-size:13px;color:#475569;margin-top:2px;">Sync to load alerts from GHAS, Dependabot, and Secret Scanning.</div>
-            </div>
-            <button id="sync-alerts-btn" onclick="syncGithubAlerts()" style="display:inline-flex;align-items:center;gap:8px;background:linear-gradient(135deg,rgba(0,229,255,0.12),rgba(99,102,241,0.12));border:1px solid rgba(0,229,255,0.25);color:#00e5ff;padding:9px 18px;border-radius:10px;font-size:14px;font-weight:500;cursor:pointer;transition:all 0.2s;" onmouseover="this.style.background='linear-gradient(135deg,rgba(0,229,255,0.2),rgba(99,102,241,0.2))'" onmouseout="this.style.background='linear-gradient(135deg,rgba(0,229,255,0.12),rgba(99,102,241,0.12))'">
-              <i data-lucide="shield-check" style="width:15px;height:15px;"></i> Sync GitHub Alerts
+          <div style="display:flex;gap:4px;margin-bottom:20px;border-bottom:1px solid rgba(255,255,255,0.06);padding-bottom:12px;">
+            <button class="subtab-btn active" id="subtab-commits" onclick="switchSubTab('commits')">
+              <i data-lucide="git-commit" style="width:13px;height:13px;display:inline;vertical-align:middle;margin-right:5px;"></i>Commits
+            </button>
+            <button class="subtab-btn" id="subtab-prs" onclick="switchSubTab('prs')">
+              <i data-lucide="git-pull-request" style="width:13px;height:13px;display:inline;vertical-align:middle;margin-right:5px;"></i>Pull Requests
+            </button>
+            <button class="subtab-btn" id="subtab-security" onclick="switchSubTab('security')">
+              <i data-lucide="shield-check" style="width:13px;height:13px;display:inline;vertical-align:middle;margin-right:5px;"></i>Security
             </button>
           </div>
-          <div id="github-alerts-list"><div style="text-align:center;padding:48px;color:#475569;"><i data-lucide="github" style="width:40px;height:40px;display:block;margin:0 auto 12px;opacity:0.25;"></i><div style="font-size:16px;color:#64748b;">Click "Sync GitHub Alerts" to load findings from GitHub Advanced Security</div></div></div>
+
+          <!-- Commits sub-pane -->
+          <div id="subpane-commits">
+            <div id="commits-list">
+              <div style="text-align:center;padding:48px;color:#475569;">
+                <i data-lucide="git-commit" style="width:40px;height:40px;display:block;margin:0 auto 12px;opacity:0.25;"></i>
+                <div style="font-size:16px;color:#64748b;">Loading recent commits...</div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Pull Requests sub-pane -->
+          <div id="subpane-prs" style="display:none;">
+            <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:16px;flex-wrap:wrap;gap:8px;">
+              <div style="display:flex;align-items:center;gap:12px;">
+                <label style="font-size:13px;color:#94a3b8;font-weight:500;">Recent PRs:</label>
+                <select id="pr-limit-select" style="background:rgba(0,0,0,0.2);border:1px solid rgba(0,229,255,0.2);color:#f1f5f9;padding:6px 10px;border-radius:8px;font-size:14px;outline:none;" onchange="loadPRsTab()">
+                  <option value="10">Last 10</option>
+                  <option value="20" selected>Last 20</option>
+                  <option value="50">Last 50</option>
+                </select>
+              </div>
+              <button onclick="loadPRsTab()" style="display:inline-flex;align-items:center;gap:8px;background:linear-gradient(135deg,rgba(0,229,255,0.12),rgba(99,102,241,0.12));border:1px solid rgba(0,229,255,0.25);color:#00e5ff;padding:8px 16px;border-radius:8px;font-size:14px;font-weight:500;cursor:pointer;transition:all 0.2s;" onmouseover="this.style.background='linear-gradient(135deg,rgba(0,229,255,0.2),rgba(99,102,241,0.2))'" onmouseout="this.style.background='linear-gradient(135deg,rgba(0,229,255,0.12),rgba(99,102,241,0.12))'">
+                <i data-lucide="refresh-cw" style="width:14px;height:14px;"></i> Refresh
+              </button>
+            </div>
+            <div id="pr-stats-row" style="display:none;grid-template-columns:repeat(4,1fr);gap:12px;margin-bottom:20px;">
+              <div style="background:rgba(0,0,0,0.2);border:1px solid rgba(0,229,255,0.1);border-radius:10px;padding:16px;text-align:center;">
+                <div id="pr-stat-total" style="font-size:28px;font-weight:700;color:#00e5ff;font-family:'Fira Code',monospace;">0</div>
+                <div style="font-size:11px;color:#475569;margin-top:4px;text-transform:uppercase;letter-spacing:1px;">PRs Analysed</div>
+              </div>
+              <div style="background:rgba(0,0,0,0.2);border:1px solid rgba(0,229,255,0.1);border-radius:10px;padding:16px;text-align:center;">
+                <div id="pr-stat-issues" style="font-size:28px;font-weight:700;color:#f87171;font-family:'Fira Code',monospace;">0</div>
+                <div style="font-size:11px;color:#475569;margin-top:4px;text-transform:uppercase;letter-spacing:1px;">PRs with Findings</div>
+              </div>
+              <div style="background:rgba(0,0,0,0.2);border:1px solid rgba(0,229,255,0.1);border-radius:10px;padding:16px;text-align:center;">
+                <div id="pr-stat-introduced" style="font-size:28px;font-weight:700;color:#fb923c;font-family:'Fira Code',monospace;">0</div>
+                <div style="font-size:11px;color:#475569;margin-top:4px;text-transform:uppercase;letter-spacing:1px;">Findings Introduced</div>
+              </div>
+              <div style="background:rgba(0,0,0,0.2);border:1px solid rgba(0,229,255,0.1);border-radius:10px;padding:16px;text-align:center;">
+                <div id="pr-stat-addressed" style="font-size:28px;font-weight:700;color:#34d399;font-family:'Fira Code',monospace;">0</div>
+                <div style="font-size:11px;color:#475569;margin-top:4px;text-transform:uppercase;letter-spacing:1px;">Findings Addressed</div>
+              </div>
+            </div>
+            <div id="pr-list-container">
+              <div style="text-align:center;padding:48px;color:#475569;">
+                <i data-lucide="git-pull-request" style="width:40px;height:40px;display:block;margin:0 auto 12px;opacity:0.25;"></i>
+                <div style="font-size:16px;color:#64748b;">Loading pull requests...</div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Security sub-pane -->
+          <div id="subpane-security" style="display:none;">
+            <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:20px;flex-wrap:wrap;gap:12px;">
+              <div>
+                <div style="font-size:16px;font-weight:600;color:#f1f5f9;">GitHub Advanced Security Alerts</div>
+                <div id="github-sync-info" style="font-size:13px;color:#475569;margin-top:2px;">Sync to load alerts from GHAS, Dependabot, and Secret Scanning.</div>
+              </div>
+              <button id="sync-alerts-btn" onclick="syncGithubAlerts()" style="display:inline-flex;align-items:center;gap:8px;background:linear-gradient(135deg,rgba(0,229,255,0.12),rgba(99,102,241,0.12));border:1px solid rgba(0,229,255,0.25);color:#00e5ff;padding:9px 18px;border-radius:10px;font-size:14px;font-weight:500;cursor:pointer;transition:all 0.2s;" onmouseover="this.style.background='linear-gradient(135deg,rgba(0,229,255,0.2),rgba(99,102,241,0.2))'" onmouseout="this.style.background='linear-gradient(135deg,rgba(0,229,255,0.12),rgba(99,102,241,0.12))'">
+                <i data-lucide="shield-check" style="width:15px;height:15px;"></i> Sync GitHub Alerts
+              </button>
+            </div>
+            <div id="github-alerts-list"><div style="text-align:center;padding:48px;color:#475569;"><i data-lucide="github" style="width:40px;height:40px;display:block;margin:0 auto 12px;opacity:0.25;"></i><div style="font-size:16px;color:#64748b;">Click "Sync GitHub Alerts" to load findings from GitHub Advanced Security</div></div></div>
+          </div>
         </div>
       </div>
     </main>
@@ -339,12 +431,19 @@ function renderAppInfo(app){
 
   const scheduleLabel = app.scan_schedule === 'none' ? 'Manual only' : app.scan_schedule || 'Manual only';
   document.getElementById('app-info-card').innerHTML = `
-    <h2 style="font-size:24px;font-weight:800;color:#f1f5f9;margin:0 0 10px;">${escHtml(app.name||'—')}</h2>
+    <div style="position:relative;">
+    ${repoUrl ? `<a href="${repoUrl}" target="_blank" rel="noopener noreferrer"
+         style="position:absolute;top:0;right:0;width:34px;height:34px;background:rgba(0,0,0,0.3);border:1px solid rgba(255,255,255,0.1);border-radius:8px;display:flex;align-items:center;justify-content:center;color:#94a3b8;text-decoration:none;transition:all 0.2s;z-index:1;"
+         title="${escHtml(app.github_org)}/${escHtml(app.github_repo)} — View on GitHub"
+         onmouseover="this.style.borderColor='rgba(0,229,255,0.4)';this.style.color='#00e5ff';this.style.background='rgba(0,229,255,0.1)'"
+         onmouseout="this.style.borderColor='rgba(255,255,255,0.1)';this.style.color='#94a3b8';this.style.background='rgba(0,0,0,0.3)'">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+      </a>` : ''}
+    <h2 style="font-size:24px;font-weight:800;color:#f1f5f9;margin:0 0 10px;${repoUrl ? 'padding-right:44px;' : ''}">${escHtml(app.name||'—')}</h2>
     <div style="display:flex;flex-wrap:wrap;gap:8px;margin-bottom:16px;">
       ${app.team_name ? `<span style="background:rgba(0,229,255,0.1);color:#00e5ff;border:1px solid rgba(0,229,255,0.2);padding:3px 10px;border-radius:6px;font-size:14px;font-weight:500;">${escHtml(app.team_name)}</span>` : ''}
       ${app.language ? `<span style="background:${lc}22;color:${lc};border:1px solid ${lc}44;padding:3px 10px;border-radius:6px;font-size:14px;font-weight:500;">${escHtml(app.language)}</span>` : ''}
     </div>
-    ${repoUrl ? `<a href="${repoUrl}" target="_blank" rel="noopener noreferrer" style="display:inline-flex;align-items:center;gap:6px;color:#00e5ff;text-decoration:none;font-size:15px;font-weight:500;margin-bottom:14px;"><i data-lucide="github" style="width:15px;height:15px;"></i>${escHtml(app.github_org)}/${escHtml(app.github_repo)}<i data-lucide="external-link" style="width:12px;height:12px;"></i></a>` : ''}
     ${app.description ? `<p style="font-size:16px;color:#94a3b8;line-height:1.6;margin:0 0 16px;">${escHtml(app.description)}</p>` : '<p style="font-size:16px;color:#475569;margin:0 0 16px;font-style:italic;">No description provided.</p>'}
     <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px;margin-top:8px;">
       <div style="background:rgba(0,0,0,0.25);border:1px solid rgba(255,255,255,0.06);border-radius:10px;padding:12px 14px;">
@@ -363,6 +462,7 @@ function renderAppInfo(app){
         <div style="font-size:12px;font-weight:600;color:#475569;text-transform:uppercase;letter-spacing:0.8px;margin-bottom:4px;">${app.container_image ? 'Container Image' : 'Added'}</div>
         <div style="font-size:15px;font-weight:500;color:#e2e8f0;font-family:'Fira Code',monospace;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;" title="${escHtml(app.container_image||'')}">${escHtml(app.container_image || formatDate(app.created_at))}</div>
       </div>
+    </div>
     </div>
   `;
   lucide.createIcons();
@@ -753,6 +853,9 @@ function resetRemediationModal(){
 }
 
 // ── Tabs ───────────────────────────────────────────────────────────────────────
+let activeSubTab = 'commits';
+let commitsLoaded = false;
+
 function switchTab(tab){
   ['findings','scans','remediations','github'].forEach(t=>{
     document.getElementById(`pane-${t}`).style.display=t===tab?'block':'none';
@@ -760,7 +863,188 @@ function switchTab(tab){
   });
   if(tab==='scans')loadScansTab();
   if(tab==='remediations')loadRemediationsTab();
-  if(tab==='github')loadGithubTab();
+  if(tab==='github')switchSubTab(activeSubTab);
+}
+
+function switchSubTab(subtab){
+  activeSubTab = subtab;
+  ['commits','prs','security'].forEach(t=>{
+    document.getElementById(`subpane-${t}`).style.display=t===subtab?'block':'none';
+    document.getElementById(`subtab-${t}`).className=`subtab-btn${t===subtab?' active':''}`;
+  });
+  if(subtab==='commits')loadCommitsSubTab();
+  if(subtab==='prs')loadPRsTab();
+  if(subtab==='security')loadGithubSecuritySubTab();
+}
+
+async function loadCommitsSubTab(){
+  if(commitsLoaded)return;
+  const el=document.getElementById('commits-list');
+  el.innerHTML='<div style="text-align:center;padding:32px;"><div style="animation:spin 1s linear infinite;display:inline-block;width:24px;height:24px;border:2px solid rgba(255,255,255,0.1);border-top-color:#00e5ff;border-radius:50%;"></div></div>';
+  try{
+    const res=await fetch(`/api/v1/github/apps/${appId}/commits?limit=30`);
+    if(!res.ok){const err=await res.json().catch(()=>({}));throw new Error(err.detail||res.statusText);}
+    const data=await res.json();
+    renderCommitsSubTab(data.commits||[]);
+    commitsLoaded=true;
+  }catch(e){
+    el.innerHTML=`<div style="text-align:center;padding:48px;color:#475569;">
+      <i data-lucide="github" style="width:40px;height:40px;display:block;margin:0 auto 12px;opacity:0.25;"></i>
+      <div style="font-size:16px;color:#64748b;margin-bottom:8px;">Could not load commits</div>
+      <div style="font-size:14px;color:#475569;">${escHtml(e.message)}</div>
+    </div>`;
+    lucide.createIcons();
+  }
+}
+
+function renderCommitsSubTab(commits){
+  const el=document.getElementById('commits-list');
+  if(!commits||commits.length===0){
+    el.innerHTML=`<div style="text-align:center;padding:60px;color:#475569;">
+      <i data-lucide="git-commit" style="width:44px;height:44px;display:block;margin:0 auto 14px;opacity:0.2;"></i>
+      <div style="font-size:17px;font-weight:500;color:#f1f5f9;margin-bottom:8px;">No Recent Commits</div>
+      <p>No commit history found. Make sure GITHUB_TOKEN is configured.</p>
+    </div>`;
+    lucide.createIcons();return;
+  }
+  el.innerHTML=`<div style="display:flex;flex-direction:column;gap:2px;">${commits.map(c=>`
+    <div style="display:flex;align-items:center;gap:12px;padding:11px 14px;border-radius:8px;transition:background 0.15s;" onmouseover="this.style.background='rgba(255,255,255,0.03)'" onmouseout="this.style.background='transparent'">
+      ${c.author_avatar
+        ?`<img src="${escHtml(c.author_avatar)}&s=28" width="28" height="28" style="border-radius:50%;border:1px solid rgba(0,229,255,0.15);flex-shrink:0;" onerror="this.style.display='none'">`
+        :`<div style="width:28px;height:28px;background:rgba(0,229,255,0.1);border-radius:50%;flex-shrink:0;display:flex;align-items:center;justify-content:center;"><i data-lucide="user" style="width:14px;height:14px;color:#475569;"></i></div>`
+      }
+      <div style="flex:1;min-width:0;">
+        <div style="font-size:14px;font-weight:500;color:#e2e8f0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;" title="${escHtml(c.message)}">${escHtml(c.message||'(no message)')}</div>
+        <div style="font-size:12px;color:#475569;margin-top:2px;display:flex;align-items:center;gap:8px;">
+          ${c.author_login
+            ?`<a href="https://github.com/${escHtml(c.author_login)}" target="_blank" style="color:#94a3b8;text-decoration:none;" onmouseover="this.style.color='#00e5ff'" onmouseout="this.style.color='#94a3b8'">@${escHtml(c.author_login)}</a>`
+            :`<span>${escHtml(c.author_name||'Unknown')}</span>`
+          }
+          <span style="color:#334155;">·</span>
+          <span>${timeAgo(c.date)}</span>
+        </div>
+      </div>
+      <div style="display:flex;align-items:center;gap:8px;flex-shrink:0;">
+        <span style="font-size:12px;font-family:'Fira Code',monospace;color:#475569;background:rgba(0,0,0,0.3);padding:2px 8px;border-radius:4px;">${escHtml(c.short_sha||'')}</span>
+        ${c.commit_url?`<a href="${escHtml(c.commit_url)}" target="_blank" style="color:#475569;display:flex;align-items:center;" title="View on GitHub" onmouseover="this.style.color='#00e5ff'" onmouseout="this.style.color='#475569'"><i data-lucide="external-link" style="width:13px;height:13px;"></i></a>`:''}
+      </div>
+    </div>
+  `).join('')}</div>`;
+  lucide.createIcons();
+}
+
+function prTypeBadge(type){
+  const m={sast:{color:'#a855f7',bg:'rgba(168,85,247,0.15)'},sca:{color:'#3b82f6',bg:'rgba(59,130,246,0.15)'},container:{color:'#0ea5e9',bg:'rgba(14,165,233,0.15)'},secrets:{color:'#f43f5e',bg:'rgba(244,63,94,0.15)'},iac:{color:'#f59e0b',bg:'rgba(245,158,11,0.15)'}};
+  const k=(type||'').toLowerCase();
+  const s=m[k]||{color:'#94a3b8',bg:'rgba(148,163,184,0.15)'};
+  return `<span style="background:${s.bg};color:${s.color};border:1px solid ${s.color}33;padding:2px 7px;border-radius:5px;font-size:11px;font-weight:600;text-transform:uppercase;">${escHtml(type||'—')}</span>`;
+}
+
+function prStateBadge(pr){
+  if(pr.draft)  return '<span class="pr-state-badge pr-state-draft"><i data-lucide="file-edit" style="width:12px;height:12px;"></i>Draft</span>';
+  if(pr.merged) return '<span class="pr-state-badge pr-state-merged"><i data-lucide="git-merge" style="width:12px;height:12px;"></i>Merged</span>';
+  if(pr.state==='open')return '<span class="pr-state-badge pr-state-open"><i data-lucide="git-pull-request" style="width:12px;height:12px;"></i>Open</span>';
+  return '<span class="pr-state-badge pr-state-closed"><i data-lucide="git-pull-request-closed" style="width:12px;height:12px;"></i>Closed</span>';
+}
+
+function renderPRFindingRow(f){
+  const alertLink=f.github_alert_url?`<a href="${escHtml(f.github_alert_url)}" target="_blank" rel="noopener" title="View on GitHub" style="flex-shrink:0;"><i data-lucide="external-link" style="width:13px;height:13px;"></i></a>`:'';
+  const findingLink=`<a href="/findings.html?identifier=${encodeURIComponent(f.rule_id||f.cve_id||'')}" title="View in Findings Hub">${escHtml(f.title)}</a>`;
+  return `<div class="finding-row">
+    ${severityBadge(f.severity)}
+    ${prTypeBadge(f.finding_type)}
+    <span style="flex:1;font-size:14px;color:#e2e8f0;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${findingLink}</span>
+    ${f.file_path?`<span style="font-size:12px;color:#475569;font-family:'Fira Code',monospace;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:200px;" title="${escHtml(f.file_path)}">${escHtml(f.file_path)}${f.line_number?':'+f.line_number:''}</span>`:''}
+    <span style="font-size:12px;color:#64748b;font-family:'Fira Code',monospace;flex-shrink:0;">${escHtml(f.scanner)}</span>
+    ${alertLink}
+  </div>`;
+}
+
+function renderPRCard(pr,index){
+  const introduced=pr.findings_introduced||[];
+  const addressed=pr.findings_addressed||[];
+  const hasFindings=introduced.length>0||addressed.length>0;
+  const panelId=`pr-panel-${index}`;
+  const chevronId=`pr-chevron-${index}`;
+  const openBadge=introduced.length>0?`<span class="count-pill count-pill-danger"><i data-lucide="alert-triangle" style="width:11px;height:11px;"></i>${introduced.length} introduced</span>`:'';
+  const addressedBadge=addressed.length>0?`<span class="count-pill count-pill-success"><i data-lucide="check-circle" style="width:11px;height:11px;"></i>${addressed.length} addressed</span>`:'';
+  const cleanBadge=!hasFindings?`<span class="count-pill count-pill-neutral"><i data-lucide="shield-check" style="width:11px;height:11px;"></i>No findings</span>`:'';
+  const authorHtml=pr.author?`<a href="${escHtml(pr.author_url||'#')}" target="_blank" rel="noopener" style="color:#94a3b8;text-decoration:none;font-size:13px;display:flex;align-items:center;gap:4px;"><i data-lucide="user" style="width:13px;height:13px;"></i>${escHtml(pr.author)}</a>`:'';
+  const branchHtml=pr.base_branch?`<span style="font-size:12px;color:#475569;display:flex;align-items:center;gap:4px;"><i data-lucide="git-branch" style="width:12px;height:12px;"></i><span style="font-family:'Fira Code',monospace;">${escHtml(pr.head_branch||'')} → ${escHtml(pr.base_branch)}</span></span>`:'';
+  let findingsHtml='';
+  if(introduced.length>0){findingsHtml+=`<div class="section-label">// Security findings introduced (${introduced.length})</div>`;findingsHtml+=introduced.map(renderPRFindingRow).join('');}
+  if(addressed.length>0){findingsHtml+=`<div class="section-label" style="margin-top:${introduced.length>0?14:0}px;">// Security findings addressed (${addressed.length})</div>`;findingsHtml+=addressed.map(renderPRFindingRow).join('');}
+  return `<div class="pr-card">
+    <div class="pr-header" ${hasFindings?`onclick="togglePRPanel('${panelId}','${chevronId}')"`:''} style="${hasFindings?'cursor:pointer;':'cursor:default;'}">
+      <div style="margin-top:2px;">${prStateBadge(pr)}</div>
+      <div style="flex:1;min-width:0;">
+        <div style="display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin-bottom:6px;">
+          <span style="font-size:15px;font-weight:600;color:#f1f5f9;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:500px;" title="${escHtml(pr.title)}">
+            <a href="${escHtml(pr.pr_url)}" target="_blank" rel="noopener" style="color:#f1f5f9;text-decoration:none;" onclick="event.stopPropagation();">#${pr.pr_number} ${escHtml(pr.title)}</a>
+          </span>
+        </div>
+        <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap;">
+          ${authorHtml}${branchHtml}
+          <span style="font-size:12px;color:#475569;display:flex;align-items:center;gap:4px;"><i data-lucide="clock" style="width:12px;height:12px;"></i>${timeAgo(pr.merged_at||pr.closed_at||pr.updated_at)}</span>
+        </div>
+        <div style="display:flex;gap:8px;margin-top:10px;flex-wrap:wrap;">${openBadge}${addressedBadge}${cleanBadge}</div>
+      </div>
+      ${hasFindings?`<i id="${chevronId}" data-lucide="chevron-down" class="chevron-icon" style="width:18px;height:18px;color:#475569;margin-top:2px;"></i>`:''}
+    </div>
+    <div id="${panelId}" class="findings-panel">${findingsHtml}</div>
+  </div>`;
+}
+
+function togglePRPanel(panelId,chevronId){
+  const panel=document.getElementById(panelId);
+  const chevron=document.getElementById(chevronId);
+  if(!panel)return;
+  const isOpen=panel.classList.contains('open');
+  panel.classList.toggle('open',!isOpen);
+  if(chevron)chevron.classList.toggle('rotated',!isOpen);
+  if(!isOpen)lucide.createIcons();
+}
+
+async function loadPRsTab(){
+  const limit=document.getElementById('pr-limit-select')?.value||20;
+  const container=document.getElementById('pr-list-container');
+  const statsRow=document.getElementById('pr-stats-row');
+  container.innerHTML=`<div style="text-align:center;padding:60px;"><div style="animation:spin 1s linear infinite;display:inline-block;width:24px;height:24px;border:2px solid rgba(255,255,255,0.1);border-top-color:#00e5ff;border-radius:50%;"></div></div>`;
+  if(statsRow)statsRow.style.display='none';
+  try{
+    const res=await fetch(`/api/v1/github/apps/${appId}/pr-reviews?limit=${limit}`);
+    if(!res.ok){
+      const err=await res.json().catch(()=>({}));
+      container.innerHTML=`<div style="text-align:center;padding:48px;color:#475569;"><i data-lucide="alert-triangle" style="width:40px;height:40px;display:block;margin:0 auto 12px;opacity:0.3;"></i><div style="font-size:16px;color:#f87171;margin-bottom:6px;">Error loading PR data</div><div style="font-size:14px;">${escHtml(err.detail||res.statusText)}</div></div>`;
+      lucide.createIcons();return;
+    }
+    const data=await res.json();
+    const prs=data.prs||[];
+    if(prs.length===0){
+      container.innerHTML=`<div style="text-align:center;padding:60px;color:#475569;"><i data-lucide="git-pull-request" style="width:44px;height:44px;display:block;margin:0 auto 14px;opacity:0.2;"></i><div style="font-size:17px;font-weight:500;color:#f1f5f9;margin-bottom:8px;">No Pull Requests Found</div><p>No recent PRs found for this repository.</p></div>`;
+      lucide.createIcons();return;
+    }
+    let totalIntroduced=0,totalAddressed=0,prsWithIssues=0;
+    prs.forEach(pr=>{totalIntroduced+=(pr.findings_introduced||[]).length;totalAddressed+=(pr.findings_addressed||[]).length;if((pr.findings_introduced||[]).length>0)prsWithIssues++;});
+    document.getElementById('pr-stat-total').textContent=data.total_prs;
+    document.getElementById('pr-stat-issues').textContent=prsWithIssues;
+    document.getElementById('pr-stat-introduced').textContent=totalIntroduced;
+    document.getElementById('pr-stat-addressed').textContent=totalAddressed;
+    if(statsRow)statsRow.style.display='grid';
+    container.innerHTML=prs.map((pr,i)=>renderPRCard(pr,i)).join('');
+    lucide.createIcons();
+    prs.forEach((pr,i)=>{
+      if((pr.findings_introduced||[]).length>0||(pr.findings_addressed||[]).length>0){
+        const panel=document.getElementById(`pr-panel-${i}`);
+        const chevron=document.getElementById(`pr-chevron-${i}`);
+        if(panel)panel.classList.add('open');
+        if(chevron)chevron.classList.add('rotated');
+      }
+    });
+  }catch(e){
+    container.innerHTML=`<div style="text-align:center;padding:48px;color:#475569;"><i data-lucide="alert-triangle" style="width:40px;height:40px;display:block;margin:0 auto 12px;opacity:0.3;"></i><div style="font-size:16px;color:#f87171;">${escHtml(String(e))}</div></div>`;
+    lucide.createIcons();
+  }
 }
 
 async function runScan(){
@@ -844,7 +1128,7 @@ async function loadRemediationsTab(){
   }
 }
 
-async function loadGithubTab(){
+async function loadGithubSecuritySubTab(){
   const el=document.getElementById('github-alerts-list');
   const infoEl=document.getElementById('github-sync-info');
   // Update last sync info from appData
@@ -943,7 +1227,7 @@ async function syncGithubAlerts(){
     const res=await fetch(`/api/v1/github/apps/${appId}/sync-alerts`,{method:'POST'});
     if(!res.ok)throw new Error((await res.json()).detail||'Sync failed');
     showToast('GitHub alerts sync started — refreshing in 5s…','success');
-    setTimeout(()=>loadGithubTab(),5000);
+    setTimeout(()=>loadGithubSecuritySubTab(),5000);
   }catch(e){showToast(e.message,'error');}
   finally{
     btn.disabled=false;

--- a/frontend/static/js/sidebar.js
+++ b/frontend/static/js/sidebar.js
@@ -31,7 +31,6 @@
         { href: '/index.html',        icon: 'layout-dashboard', label: 'Dashboard',    matchPaths: ['/index.html', '/'] },
         { href: '/applications.html', icon: 'server',           label: 'Applications', matchPaths: ['/applications.html', '/app-detail.html'] },
         { href: '/findings.html',     icon: 'list',             label: 'Findings',     matchPaths: ['/findings.html'] },
-        { href: '/pr-reviews.html',   icon: 'git-pull-request', label: 'PR Reviews',   matchPaths: ['/pr-reviews.html'] },
         { href: '/reports.html',      icon: 'bar-chart-3',      label: 'Reports',      matchPaths: ['/reports.html'] },
         { href: '/secrets.html',      icon: 'key',              label: 'Secrets',      matchPaths: ['/secrets.html'] },
         { href: '/threat-intel.html', icon: 'radar',            label: 'Threat Intel', matchPaths: ['/threat-intel.html'] },
@@ -124,7 +123,7 @@
   }).join('');
 
   var sidebarHTML = ''
-    + '<aside id="sidebar" style="width:260px;min-height:100vh;background:#060712;border-right:1px solid rgba(0,229,255,0.10);display:flex;flex-direction:column;position:fixed;left:0;top:0;z-index:100;">'
+    + '<aside id="sidebar" style="width:260px;height:100vh;overflow:hidden;background:#060712;border-right:1px solid rgba(0,229,255,0.10);display:flex;flex-direction:column;position:fixed;left:0;top:0;z-index:100;">'
     +   '<div style="padding:24px 20px;border-bottom:1px solid rgba(0,229,255,0.08);display:flex;align-items:center;gap:12px;">'
     +     '<div style="width:40px;height:40px;background:linear-gradient(135deg,rgba(0,229,255,0.2),rgba(99,102,241,0.2));border:1px solid rgba(0,229,255,0.5);border-radius:12px;display:flex;align-items:center;justify-content:center;box-shadow:0 0 20px rgba(0,229,255,0.2),inset 0 0 10px rgba(0,229,255,0.05);">'
     +       '<i data-lucide="shield-alert" style="width:20px;height:20px;color:#00e5ff;"></i>'


### PR DESCRIPTION
## Summary

- **Sidebar cleanup**: Removed standalone "PR Reviews" nav item; fixed sidebar scroll by changing `min-height:100vh` → `height:100vh;overflow:hidden` on the `<aside>` element so the nav scrolls correctly when there are many items
- **GitHub tab restructure** on app-detail page: renamed "GitHub Security" → "GitHub" with three sub-tabs:
  - **Commits** — new endpoint `GET /api/v1/github/apps/{id}/commits` backed by `fetch_recent_commits()` in `github_service.py`; shows avatar, first-line message, author login, time ago, short SHA
  - **Pull Requests** — PR reviews content moved from the standalone `/pr-reviews.html` page into the application context
  - **Security** — existing GHAS alerts tab preserved unchanged
- **GitHub logo button**: replaced the inline "org/repo" text link with a 34×34px SVG GitHub icon button positioned absolutely in the top-right corner of the app info card (hover → cyan highlight)
- **GHAS deduplication**: added `_has_native_duplicate()` in `github_tasks.py` — before inserting a new GHAS finding, checks if a native scanner (semgrep, grype, trivy, etc.) already tracks the same CVE+package (Dependabot) or rule_id+file_path (code scanning). Secret scanning is always preserved.

## Test plan

- [ ] 164 backend tests pass (`python -m pytest tests/ -v`)
- [ ] Navigate any page — sidebar nav scrolls without bottom items being cut off; no PR Reviews item
- [ ] Open an app with GitHub configured — GitHub tab → Commits shows recent commits; Pull Requests shows PR cards; Security has Sync button
- [ ] GitHub icon button top-right of app info card links to correct GitHub repo; hover turns cyan
- [ ] Sync GHAS alerts on app that already has Semgrep/Grype findings — task logs show skipped GHAS findings where native duplicates exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)