### PR TITLE
fix: remove broken Shadowserver feed and add favicon

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Snitch is an AppSec platform that aggregates security findings from Semgrep (SAS
 **New features (v1.6+):**
 - **Global Findings Hub** (`/findings.html`) — paginated view of all findings across all apps; filters for Severity, Type, Scanner, Status; default sort by severity; sortable by Severity or Date Discovered; slide-in detail panel with live status editing; deep-linked from dashboard severity cards.
 - **Compliance Posture** (`/compliance.html`) — maps findings to 5 frameworks: OWASP Top 10 2021, PCI-DSS v4.0, CIS Benchmarks, DORA, SOC 2 Type II. Shows per-framework compliance score (% controls with zero violations) as an SVG ring, control drill-down links to filtered findings, and a "Reapply Tags" button.
-- **Threat Intelligence** (`/threat-intel.html`) — aggregates live RSS feeds from 7 threat intel sources (The Hacker News, Bleeping Computer, CISA, Wiz, Krebs, Shadowserver, Dark Reading) with a 3D globe visualisation of active threat locations (powered by globe.gl + Claude AI if API key is set).
+- **Threat Intelligence** (`/threat-intel.html`) — aggregates live RSS feeds from 6 threat intel sources (The Hacker News, Bleeping Computer, CISA, Wiz, Krebs, Dark Reading) with a 3D globe visualisation of active threat locations (powered by globe.gl + Claude AI if API key is set).
 - **EPSS Integration** — after each scan, CVE-bearing findings have their Exploit Prediction Scoring System (EPSS) score and percentile fetched from first.org and stored on the finding. The risk score calculator applies a boost (+15 or +5 pts) for findings with high EPSS percentiles.
 - **SBOM Generation** — `GET /api/v1/applications/{id}/sbom` returns a CycloneDX v1.4 JSON SBOM of all SCA/container findings for an application.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ The `/findings.html` page is the Global Findings Hub — lists all findings plat
 
 The `/compliance.html` page shows compliance posture across 5 frameworks. Each framework card has an SVG score ring (% controls passing), a control breakdown table, and "View findings →" links that navigate to the filtered findings page. The "Reapply Tags" button calls `POST /api/v1/reports/compliance/retag` to re-apply the current rule set to all findings. Tags are stored as JSON arrays on each `Finding` row (e.g. `["OWASP Top 10 2021|A03 — Injection"]`) and applied at scan time by `apply_compliance_tags()` in `services/compliance.py`.
 
-The `/threat-intel.html` page aggregates live RSS from 7 cybersecurity news sources and renders them as cards alongside a 3D globe (globe.gl) showing threat locations. Locations are extracted by the configured LLM provider (`/api/v1/threat-intel/locations`) — works with Anthropic or Ollama; falls back to a keyword matcher if no provider is configured.
+The `/threat-intel.html` page aggregates live RSS from 6 cybersecurity news sources and renders them as cards alongside a 3D globe (globe.gl) showing threat locations. Locations are extracted by the configured LLM provider (`/api/v1/threat-intel/locations`) — works with Anthropic or Ollama; falls back to a keyword matcher if no provider is configured.
 
 ## Commands
 

--- a/backend/app/api/v1/threat_intel.py
+++ b/backend/app/api/v1/threat_intel.py
@@ -15,7 +15,6 @@ FEEDS = [
     {"url": "https://www.bleepingcomputer.com/feed/", "name": "Bleeping Computer"},
     {"url": "https://www.wiz.io/api/feed/cloud-threat-landscape/rss.xml", "name": "Wiz Cloud"},
     {"url": "https://www.cisa.gov/cybersecurity-advisories/all.xml", "name": "CISA Alerts"},
-    {"url": "https://www.shadowserver.org/feed/", "name": "Shadowserver"},
     {"url": "https://krebsonsecurity.com/feed/", "name": "Krebs on Security"},
     {"url": "https://www.darkreading.com/rss.xml", "name": "Dark Reading"}
 ]

--- a/frontend/about.html
+++ b/frontend/about.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" href="/static/favicon.svg" type="image/svg+xml">
   <title>Snitch — About</title>
   <script>(function(){document.documentElement.setAttribute('data-theme',localStorage.getItem('theme')||'light');})();</script>
   <style>/* Inter font fallback */ body { font-family: var(--font-body); }</style>

--- a/frontend/app-detail.html
+++ b/frontend/app-detail.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" href="/static/favicon.svg" type="image/svg+xml">
   <title>Snitch — Application Detail</title>
   <script>(function(){document.documentElement.setAttribute('data-theme',localStorage.getItem('theme')||'light');})();</script>
   <style>/* Inter font fallback */ body { font-family: var(--font-body); }</style>

--- a/frontend/applications.html
+++ b/frontend/applications.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" href="/static/favicon.svg" type="image/svg+xml">
   <title>Snitch — Applications</title>
   <script>(function(){document.documentElement.setAttribute('data-theme',localStorage.getItem('theme')||'light');})();</script>
   <style>/* Inter font fallback */ body { font-family: var(--font-body); }</style>

--- a/frontend/compliance.html
+++ b/frontend/compliance.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" href="/static/favicon.svg" type="image/svg+xml">
   <title>Snitch — Compliance Posture</title>
   <script>(function(){document.documentElement.setAttribute('data-theme',localStorage.getItem('theme')||'light');})();</script>
   <style>/* Inter font fallback */ body { font-family: var(--font-body); }</style>

--- a/frontend/findings.html
+++ b/frontend/findings.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" href="/static/favicon.svg" type="image/svg+xml">
   <title>Snitch — Global Findings</title>
   <script>(function(){document.documentElement.setAttribute('data-theme',localStorage.getItem('theme')||'light');})();</script>
   <style>/* Inter font fallback */ body { font-family: var(--font-body); }</style>

--- a/frontend/help.html
+++ b/frontend/help.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" href="/static/favicon.svg" type="image/svg+xml">
   <title>Snitch — Documentation</title>
   <script>(function(){document.documentElement.setAttribute('data-theme',localStorage.getItem('theme')||'light');})();</script>
   <style>/* Inter font fallback */ body { font-family: var(--font-body); }</style>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" href="/static/favicon.svg" type="image/svg+xml">
   <title>Snitch — Security Overview</title>
   <script>(function(){document.documentElement.setAttribute('data-theme',localStorage.getItem('theme')||'light');})();</script>
   <link rel="stylesheet" href="/static/css/theme.css">

--- a/frontend/integrations.html
+++ b/frontend/integrations.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" href="/static/favicon.svg" type="image/svg+xml">
   <title>Snitch — Integrations</title>
   <script>(function(){document.documentElement.setAttribute('data-theme',localStorage.getItem('theme')||'light');})();</script>
   <link rel="stylesheet" href="/static/css/theme.css">

--- a/frontend/policies.html
+++ b/frontend/policies.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" href="/static/favicon.svg" type="image/svg+xml">
   <title>Snitch — Security Policies</title>
   <script>(function(){document.documentElement.setAttribute('data-theme',localStorage.getItem('theme')||'light');})();</script>
   <style>/* Inter font fallback */ body { font-family: var(--font-body); }</style>

--- a/frontend/pr-reviews.html
+++ b/frontend/pr-reviews.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" href="/static/favicon.svg" type="image/svg+xml">
   <title>Snitch — PR Reviews</title>
   <script>(function(){document.documentElement.setAttribute('data-theme',localStorage.getItem('theme')||'light');})();</script>
   <style>/* Inter font fallback */ body { font-family: var(--font-body); }</style>

--- a/frontend/profile.html
+++ b/frontend/profile.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" href="/static/favicon.svg" type="image/svg+xml">
   <title>Snitch — Profile &amp; Preferences</title>
   <script>(function(){document.documentElement.setAttribute('data-theme',localStorage.getItem('theme')||'light');})();</script>
   <link rel="stylesheet" href="/static/css/theme.css">

--- a/frontend/reports.html
+++ b/frontend/reports.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" href="/static/favicon.svg" type="image/svg+xml">
   <title>Snitch — Security Reports</title>
   <script>(function(){document.documentElement.setAttribute('data-theme',localStorage.getItem('theme')||'light');})();</script>
   <style>/* Inter font fallback */ body { font-family: var(--font-body); }</style>

--- a/frontend/repositories.html
+++ b/frontend/repositories.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" href="/static/favicon.svg" type="image/svg+xml">
   <title>Snitch — Repositories</title>
   <script>(function(){document.documentElement.setAttribute('data-theme',localStorage.getItem('theme')||'light');})();</script>
   <style>/* Inter font fallback */ body { font-family: var(--font-body); }</style>

--- a/frontend/rules.html
+++ b/frontend/rules.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" href="/static/favicon.svg" type="image/svg+xml">
   <title>Snitch — Rules Library</title>
   <link rel="stylesheet" href="/static/css/theme.css">
   <script>(function(){document.documentElement.setAttribute('data-theme',localStorage.getItem('theme')||'light');})();</script>

--- a/frontend/secrets.html
+++ b/frontend/secrets.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" href="/static/favicon.svg" type="image/svg+xml">
   <title>Snitch — Secrets Scanner</title>
   <script>(function(){document.documentElement.setAttribute('data-theme',localStorage.getItem('theme')||'light');})();</script>
   <link rel="stylesheet" href="/static/css/theme.css">

--- a/frontend/service-accounts.html
+++ b/frontend/service-accounts.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" href="/static/favicon.svg" type="image/svg+xml">
   <title>Snitch — Service Accounts</title>
   <script>(function(){document.documentElement.setAttribute('data-theme',localStorage.getItem('theme')||'light');})();</script>
   <link rel="stylesheet" href="/static/css/theme.css">

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" href="/static/favicon.svg" type="image/svg+xml">
   <title>Snitch — Settings</title>
   <script>(function(){document.documentElement.setAttribute('data-theme',localStorage.getItem('theme')||'light');})();</script>
   <link rel="stylesheet" href="/static/css/theme.css">

--- a/frontend/static/favicon.svg
+++ b/frontend/static/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0f1b34"/>
+  <path d="M16 4 L28 9 L28 18 C28 24 22 29 16 31 C10 29 4 24 4 18 L4 9 Z" fill="#0ea5e9" opacity="0.9"/>
+  <path d="M16 8 L24 12 L24 18 C24 22 20 26 16 28 C12 26 8 22 8 18 L8 12 Z" fill="#0f1b34" opacity="0.6"/>
+  <circle cx="16" cy="18" r="4" fill="#ffffff" opacity="0.9"/>
+</svg>

--- a/frontend/threat-intel.html
+++ b/frontend/threat-intel.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" href="/static/favicon.svg" type="image/svg+xml">
   <title>Snitch — Threat Intelligence</title>
   <script>(function(){document.documentElement.setAttribute('data-theme',localStorage.getItem('theme')||'light');})();</script>
   <link rel="stylesheet" href="/static/css/theme.css">


### PR DESCRIPTION
## Summary

- **Closes #42** — Remove Shadowserver RSS feed from threat intel sources; the URL `https://www.shadowserver.org/feed/` returns 404 and causes an error on every fetch. Feed list reduced from 7 to 6 sources.
- **Closes #43** — Add a branded SVG shield favicon (`frontend/static/favicon.svg`) and wire it up via `<link rel="icon">` in all 18 HTML pages.

## Changes

- `backend/app/api/v1/threat_intel.py` — removed Shadowserver entry from `FEEDS` list
- `frontend/static/favicon.svg` — new shield icon using platform accent colour `#0ea5e9`
- All 18 `frontend/*.html` files — added `<link rel="icon" href="/static/favicon.svg" type="image/svg+xml">` in `<head>`
- `CLAUDE.md` — updated threat intel source count (7 → 6) and removed Shadowserver from the list

## Test plan

- [ ] Threat intel page loads without 404 errors in logs
- [ ] All browser tabs show the shield favicon
- [ ] Backend test suite: `cd backend && python3.14 -m pytest tests/ -v` (6 pre-existing failures unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)