### PR TITLE
fix: threat intel globe light mode + scroll zoom + dashboard risk card simplification (#45, #46)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ The `/findings.html` page is the Global Findings Hub — lists all findings plat
 
 The `/compliance.html` page shows compliance posture across 5 frameworks. Each framework card has an SVG score ring (% controls passing), a control breakdown table, and "View findings →" links that navigate to the filtered findings page. The "Reapply Tags" button calls `POST /api/v1/reports/compliance/retag` to re-apply the current rule set to all findings. Tags are stored as JSON arrays on each `Finding` row (e.g. `["OWASP Top 10 2021|A03 — Injection"]`) and applied at scan time by `apply_compliance_tags()` in `services/compliance.py`.
 
-The `/threat-intel.html` page aggregates live RSS from 6 cybersecurity news sources and renders them as cards alongside a 3D globe (globe.gl) showing threat locations. Locations are extracted by the configured LLM provider (`/api/v1/threat-intel/locations`) — works with Anthropic or Ollama; falls back to a keyword matcher if no provider is configured.
+The `/threat-intel.html` page aggregates live RSS from 6 cybersecurity news sources and renders them as cards alongside a 3D globe (globe.gl) showing threat locations. Locations are extracted by the configured LLM provider (`/api/v1/threat-intel/locations`) — works with Anthropic or Ollama; falls back to a keyword matcher if no provider is configured. The globe supports scroll-wheel zoom and is theme-aware: light mode uses `earth-day.jpg`, dark mode uses `earth-night.jpg`. Switching themes at runtime via the profile widget also swaps the globe texture immediately. The locations overlay panel is styled for both themes via the `.locations-panel` CSS class.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 | 🕷️ **Jira Epic Crawler** | Crawl epic child issues, match against Snitch findings, identify coverage gaps, and generate an AI remediation plan with Claude |
 | 📋 **Applications List View** | Sortable table view for the applications portfolio — click any column header to re-sort |
 | 🌍 **Track Public Repos** | Add any open source GitHub repository by URL or `org/repo` — no token needed for public repos; metadata auto-fetched via `/api/v1/github/repos/lookup` |
+| 🌍 **Threat Intel Globe** | 3D globe (globe.gl) with scroll-wheel zoom, auto-rotation, and full light/dark theme support — switches between `earth-day.jpg` and `earth-night.jpg` dynamically when theme is toggled |
 | 📚 **Developer Docs** | Built-in documentation page (`/help.html`) with Quick Start, GitHub Actions CI/CD guide (2-stage auth+push), General Usage, and API Reference |
 | ℹ️ **About & Changelog** | About page (`/about.html`) with tech stack overview and release notes for all major versions |
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -299,14 +299,10 @@
         <div class="card title-card" id="tc-risk" style="animation-delay:0.05s;">
           <div class="tc-header">
             <span class="tc-title">Risk Score</span>
-            <div class="tc-toggle">
-              <button class="tc-toggle-btn active" data-view="by_risk" onclick="switchCardView('risk','by_risk',this)">By Risk</button>
-              <button class="tc-toggle-btn" data-view="top_apps" onclick="switchCardView('risk','top_apps',this)">Top Apps</button>
-            </div>
           </div>
-          <div class="tc-gauge-row">
+          <div style="display:flex;flex-direction:column;align-items:center;justify-content:center;flex:1;padding:12px 0 20px;">
             <div class="gauge-wrap" style="flex-shrink:0;">
-              <svg width="96" height="96" viewBox="0 0 72 72">
+              <svg width="120" height="120" viewBox="0 0 72 72">
                 <circle id="gauge-track" cx="36" cy="36" r="27" fill="none" stroke="rgba(255,255,255,0.07)" stroke-width="6" stroke-linecap="round"
                   stroke-dasharray="127.2 169.6" transform="rotate(135 36 36)"/>
                 <circle cx="36" cy="36" r="27" fill="none" id="gauge-arc" stroke="#00e5ff" stroke-width="6" stroke-linecap="round"
@@ -317,16 +313,7 @@
                 <div id="m-risk" style="font-size:22px;font-weight:700;color:var(--text-primary);line-height:1;">—</div>
               </div>
             </div>
-            <div>
-              <div style="font-size:13px;font-weight:600;color:var(--text-tertiary);text-transform:uppercase;letter-spacing:0.8px;margin-bottom:3px;">Avg Platform Score</div>
-              <div id="risk-level-label" class="tc-risk-level">—</div>
-            </div>
-          </div>
-          <div class="tc-rows" id="tc-risk-rows">
-            <div class="tc-skel"></div><div class="tc-skel" style="width:85%;"></div><div class="tc-skel" style="width:70%;"></div>
-          </div>
-          <div class="tc-footer">
-            <a href="/applications.html">View all applications <i data-lucide="arrow-right" style="width:12px;height:12px;"></i></a>
+            <div id="risk-level-label" class="tc-risk-level" style="margin-top:10px;">—</div>
           </div>
         </div>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -258,7 +258,7 @@
     /* Risk score card gauge area */
     .tc-gauge-row { display: flex; align-items: center; gap: 14px; margin-bottom: 14px; }
     .tc-gauge-row .gauge-wrap { width: 96px !important; height: 96px !important; }
-    .tc-risk-level { font-size: 15px; font-weight: 600; margin-top: 4px; }
+    .tc-risk-level { font-size: 40px; font-weight: 600; margin-top: 4px; }
     .tc-skel { background: rgba(255,255,255,0.06); border-radius: 5px; height: 26px; animation: pulse 1.8s ease-in-out infinite; }
     [data-theme="light"] .tc-skel { background: rgba(0,0,0,0.06); }
     [data-theme="light"] #gauge-track { stroke: rgba(0,0,0,0.10) !important; }
@@ -301,7 +301,7 @@
             <span class="tc-title">Risk Score</span>
           </div>
           <div style="display:flex;flex-direction:column;align-items:center;flex:1;justify-content:center;padding:8px 0 12px;">
-            <div class="gauge-wrap" style="width:100%;height:auto;max-width:180px;aspect-ratio:1;flex-shrink:0;">
+            <div class="gauge-wrap" style="width:100%;height:auto;max-width:300px;aspect-ratio:1;flex-shrink:0;">
               <svg width="100%" height="100%" viewBox="0 0 72 72">
                 <circle id="gauge-track" cx="36" cy="36" r="27" fill="none" stroke="rgba(255,255,255,0.07)" stroke-width="6" stroke-linecap="round"
                   stroke-dasharray="127.2 169.6" transform="rotate(135 36 36)"/>
@@ -310,7 +310,7 @@
                   style="transition:stroke-dasharray 1.1s cubic-bezier(0.4,0,0.2,1),stroke 0.5s;"/>
               </svg>
               <div class="gauge-center">
-                <div id="m-risk" style="font-size:26px;font-weight:700;color:var(--text-primary);line-height:1;">—</div>
+                <div id="m-risk" style="font-size:50px;font-weight:700;color:var(--text-primary);line-height:1;">—</div>
               </div>
             </div>
             <div id="risk-level-label" class="tc-risk-level" style="margin-top:12px;">—</div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -301,7 +301,7 @@
             <span class="tc-title">Risk Score</span>
           </div>
           <div style="display:flex;flex-direction:column;align-items:center;flex:1;justify-content:center;padding:8px 0 12px;">
-            <div class="gauge-wrap" style="width:100%;max-width:180px;aspect-ratio:1;flex-shrink:0;">
+            <div class="gauge-wrap" style="width:100%;height:auto;max-width:180px;aspect-ratio:1;flex-shrink:0;">
               <svg width="100%" height="100%" viewBox="0 0 72 72">
                 <circle id="gauge-track" cx="36" cy="36" r="27" fill="none" stroke="rgba(255,255,255,0.07)" stroke-width="6" stroke-linecap="round"
                   stroke-dasharray="127.2 169.6" transform="rotate(135 36 36)"/>
@@ -359,15 +359,11 @@
         <div class="card title-card" id="tc-scanners" style="animation-delay:0.20s;">
           <div class="tc-header">
             <span class="tc-title">Security Scanners</span>
-            <div class="tc-toggle">
-              <button class="tc-toggle-btn active" data-view="by_scanner" onclick="switchCardView('scanners','by_scanner',this)">Scanner</button>
-              <button class="tc-toggle-btn" data-view="by_type" onclick="switchCardView('scanners','by_type',this)">Type</button>
-            </div>
           </div>
           <div class="tc-primary" id="tc-scanners-count">—</div>
           <div class="tc-sub">total findings</div>
-          <div class="tc-rows" id="tc-scanners-rows">
-            <div class="tc-skel"></div><div class="tc-skel" style="width:80%;"></div><div class="tc-skel" style="width:65%;"></div><div class="tc-skel" style="width:50%;"></div>
+          <div style="position:relative;flex:1;min-height:0;margin-top:8px;">
+            <canvas id="scanner-chart"></canvas>
           </div>
           <div class="tc-footer">
             <a href="/findings.html">View findings <i data-lucide="arrow-right" style="width:12px;height:12px;"></i></a>
@@ -642,6 +638,36 @@ function getScannerRows() {
     .map(([k,v])=>{ const n=k.toLowerCase(); return { label:n.charAt(0).toUpperCase()+n.slice(1), count:v, color:sc[n]||'#94a3b8', href:`/findings.html?scanner=${encodeURIComponent(n)}` }; });
 }
 
+function renderScannerChart(byScanner) {
+  const sc = { semgrep:'#0ea5e9', grype:'#8b5cf6', trivy:'#10b981', gitleaks:'#f59e0b', checkov:'#ef4444', govulncheck:'#f97316', dependabot:'#6366f1', codeql:'#14b8a6' };
+  const entries = Object.entries(byScanner || {}).filter(([,v]) => v > 20).sort((a,b) => b[1]-a[1]);
+  const ctx = document.getElementById('scanner-chart');
+  if (!ctx) return;
+  const isDark = document.documentElement.getAttribute('data-theme') !== 'light';
+  const gridColor = isDark ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.07)';
+  const tickColor = isDark ? '#94a3b8' : '#6b7280';
+  if (window._scannerChartInst) window._scannerChartInst.destroy();
+  window._scannerChartInst = new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: entries.map(([k]) => k.charAt(0).toUpperCase()+k.slice(1)),
+      datasets: [{ data: entries.map(([,v]) => v),
+        backgroundColor: entries.map(([k]) => (sc[k.toLowerCase()]||'#94a3b8')+'bb'),
+        borderColor:     entries.map(([k]) => sc[k.toLowerCase()]||'#94a3b8'),
+        borderWidth: 1, borderRadius: 4 }]
+    },
+    options: {
+      indexAxis: 'y', responsive: true, maintainAspectRatio: false,
+      plugins: { legend: { display: false },
+        tooltip: { callbacks: { label: c => ` ${c.raw.toLocaleString()} findings` } } },
+      scales: {
+        x: { grid: { color: gridColor }, ticks: { color: tickColor, font: { size: 11 } } },
+        y: { grid: { display: false }, ticks: { color: tickColor, font: { size: 12, weight:'600' } } }
+      }
+    }
+  });
+}
+
 function switchCardView(cardId, view, btnEl) {
   const card = document.getElementById('tc-'+cardId);
   if (!card) return;
@@ -691,8 +717,7 @@ function renderTitleCards(overview, stats, topApps) {
 
   // Card 4: Scanners
   animateCounter(document.getElementById('tc-scanners-count'), stats.total||0);
-  document.getElementById('tc-scanners-rows').innerHTML = buildRows(getScannerRows());
-  animateBars('tc-scanners-rows');
+  renderScannerChart(stats.by_scanner || {});
 }
 
 // ── 7-day Trend Chart ─────────────────────────────────────────────────────────

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -676,8 +676,8 @@ function renderTitleCards(overview, stats, topApps) {
   if (levelEl) { levelEl.textContent = risk.label; levelEl.style.color = risk.color; }
   const arc = document.getElementById('gauge-arc');
   if (arc) { const fill = 127.2*(avg/100); arc.style.strokeDasharray=`${fill} 169.6`; arc.style.stroke=risk.color; }
-  document.getElementById('tc-risk-rows').innerHTML = buildRows(getRiskBreakdownRows());
-  animateBars('tc-risk-rows');
+  const riskRowsEl = document.getElementById('tc-risk-rows');
+  if (riskRowsEl) { riskRowsEl.innerHTML = buildRows(getRiskBreakdownRows()); animateBars('tc-risk-rows'); }
 
   // Card 2: Open Findings
   animateCounter(document.getElementById('tc-findings-count'), stats.open||0);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -301,7 +301,7 @@
             <span class="tc-title">Risk Score</span>
           </div>
           <div style="display:flex;flex-direction:column;align-items:center;padding:16px 0 0;">
-            <div class="gauge-wrap" style="flex-shrink:0;">
+            <div class="gauge-wrap" style="flex-shrink:0;width:120px;height:120px;">
               <svg width="120" height="120" viewBox="0 0 72 72">
                 <circle id="gauge-track" cx="36" cy="36" r="27" fill="none" stroke="rgba(255,255,255,0.07)" stroke-width="6" stroke-linecap="round"
                   stroke-dasharray="127.2 169.6" transform="rotate(135 36 36)"/>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -300,9 +300,9 @@
           <div class="tc-header">
             <span class="tc-title">Risk Score</span>
           </div>
-          <div style="display:flex;flex-direction:column;align-items:center;padding:16px 0 0;">
-            <div class="gauge-wrap" style="flex-shrink:0;width:120px;height:120px;">
-              <svg width="120" height="120" viewBox="0 0 72 72">
+          <div style="display:flex;flex-direction:column;align-items:center;flex:1;justify-content:center;padding:8px 0 12px;">
+            <div class="gauge-wrap" style="width:100%;max-width:180px;aspect-ratio:1;flex-shrink:0;">
+              <svg width="100%" height="100%" viewBox="0 0 72 72">
                 <circle id="gauge-track" cx="36" cy="36" r="27" fill="none" stroke="rgba(255,255,255,0.07)" stroke-width="6" stroke-linecap="round"
                   stroke-dasharray="127.2 169.6" transform="rotate(135 36 36)"/>
                 <circle cx="36" cy="36" r="27" fill="none" id="gauge-arc" stroke="#00e5ff" stroke-width="6" stroke-linecap="round"
@@ -310,10 +310,10 @@
                   style="transition:stroke-dasharray 1.1s cubic-bezier(0.4,0,0.2,1),stroke 0.5s;"/>
               </svg>
               <div class="gauge-center">
-                <div id="m-risk" style="font-size:22px;font-weight:700;color:var(--text-primary);line-height:1;">—</div>
+                <div id="m-risk" style="font-size:26px;font-weight:700;color:var(--text-primary);line-height:1;">—</div>
               </div>
             </div>
-            <div id="risk-level-label" class="tc-risk-level" style="margin-top:10px;">—</div>
+            <div id="risk-level-label" class="tc-risk-level" style="margin-top:12px;">—</div>
           </div>
         </div>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -300,7 +300,7 @@
           <div class="tc-header">
             <span class="tc-title">Risk Score</span>
           </div>
-          <div style="display:flex;flex-direction:column;align-items:center;justify-content:center;flex:1;padding:12px 0 20px;">
+          <div style="display:flex;flex-direction:column;align-items:center;padding:16px 0 0;">
             <div class="gauge-wrap" style="flex-shrink:0;">
               <svg width="120" height="120" viewBox="0 0 72 72">
                 <circle id="gauge-track" cx="36" cy="36" r="27" fill="none" stroke="rgba(255,255,255,0.07)" stroke-width="6" stroke-linecap="round"

--- a/frontend/threat-intel.html
+++ b/frontend/threat-intel.html
@@ -47,6 +47,22 @@
     .apt-item:hover { background: rgba(0,229,255,0.02); }
     .apt-status { display: inline-flex; align-items: center; gap: 6px; font-size: 12px; font-weight: 700; text-transform: uppercase; letter-spacing: 1px; color: #ef4444; background: rgba(239,68,68,0.1); padding: 4px 8px; border-radius: 4px; }
     .apt-status .dot { width: 6px; height: 6px; background: #ef4444; border-radius: 50%; animation: pulse-glow 2s infinite; }
+
+    [data-theme="light"] .locations-panel {
+      background: rgba(248,250,252,0.96) !important;
+      border-color: rgba(0,0,0,0.10) !important;
+    }
+    [data-theme="light"] .feed-item {
+      background: #f8fafc;
+      border-color: rgba(0,0,0,0.08);
+    }
+    [data-theme="light"] .feed-item:hover {
+      background: #f0f9ff;
+      border-color: rgba(14,165,233,0.25);
+    }
+    [data-theme="light"] .feed-source { color: #0284c7; }
+    [data-theme="light"] .apt-item { border-bottom-color: rgba(0,0,0,0.08); }
+    [data-theme="light"] .apt-item:hover { background: rgba(14,165,233,0.04); }
   </style>
 </head>
 <body>
@@ -76,7 +92,7 @@
             <div style="font-size:14px;color:var(--text-secondary);font-family:'Fira Code',monospace;">Live network attack origins</div>
           </div>
           
-          <div id="locations-panel" style="background:rgba(10,14,26,0.85);backdrop-filter:blur(10px);border:1px solid rgba(0,229,255,0.15);border-radius:12px;padding:16px;width:300px;pointer-events:auto;max-height:330px;overflow-y:auto;box-shadow:0 10px 30px rgba(0,0,0,0.5);">
+          <div id="locations-panel" class="locations-panel" style="background:rgba(10,14,26,0.85);backdrop-filter:blur(10px);border:1px solid rgba(0,229,255,0.15);border-radius:12px;padding:16px;width:300px;pointer-events:auto;max-height:330px;overflow-y:auto;box-shadow:0 10px 30px rgba(0,0,0,0.5);">
             <div style="font-size:13px;font-weight:700;color:#00e5ff;letter-spacing:1px;text-transform:uppercase;margin-bottom:12px;display:flex;align-items:center;gap:6px;">
               <div style="width:6px;height:6px;background:#00e5ff;border-radius:50%;animation:pulse-glow 2s infinite;"></div>
               Live Intel Locations
@@ -231,18 +247,21 @@ let globeObj = null;
 
 function initGlobe() {
   const container = document.getElementById('globeViz');
+  const isDark = document.documentElement.getAttribute('data-theme') !== 'light';
   globeObj = Globe()
     (container)
-    .globeImageUrl('//unpkg.com/three-globe/example/img/earth-night.jpg')
+    .globeImageUrl(isDark
+      ? '//unpkg.com/three-globe/example/img/earth-night.jpg'
+      : '//unpkg.com/three-globe/example/img/earth-day.jpg')
     .backgroundColor('rgba(0,0,0,0)')
     .arcStroke(0.5)
     .arcDashLength(() => Math.random())
     .arcDashGap(() => Math.random())
     .arcDashAnimateTime(() => Math.random() * 4000 + 1000);
-    
+
   globeObj.controls().autoRotate = true;
   globeObj.controls().autoRotateSpeed = 1.2;
-  globeObj.controls().enableZoom = false;
+  globeObj.controls().enableZoom = true;
 
   window.addEventListener('resize', () => {
     globeObj.width(container.clientWidth);
@@ -322,6 +341,18 @@ async function loadLocations() {
     list.innerHTML = '<div style="color:#ef4444;font-size:14px;">Failed to analyze locations.</div>';
   }
 }
+
+window.applyTheme = function(theme) {
+  document.documentElement.setAttribute('data-theme', theme);
+  localStorage.setItem('theme', theme);
+  if (globeObj) {
+    globeObj.globeImageUrl(
+      theme === 'light'
+        ? '//unpkg.com/three-globe/example/img/earth-day.jpg'
+        : '//unpkg.com/three-globe/example/img/earth-night.jpg'
+    );
+  }
+};
 
 document.addEventListener('DOMContentLoaded', () => {
   lucide.createIcons();

--- a/frontend/threat-intel.html
+++ b/frontend/threat-intel.html
@@ -60,8 +60,7 @@
       background: #f0f9ff;
       border-color: rgba(14,165,233,0.25);
     }
-    [data-theme="light"] .feed-source { color: #0284c7; }
-    [data-theme="light"] .apt-item { border-bottom-color: rgba(0,0,0,0.08); }
+[data-theme="light"] .apt-item { border-bottom-color: rgba(0,0,0,0.08); }
     [data-theme="light"] .apt-item:hover { background: rgba(14,165,233,0.04); }
   </style>
 </head>
@@ -214,8 +213,11 @@ async function loadFeed() {
     }
     
     container.innerHTML = data.items.map(function(item) {
-      // Pick a random icon/color based on source hash for visual variety
-      const colors = ['#ff3333', '#ff9f43', '#00e5ff', '#ff6b35', '#a29bfe'];
+      // Pick a color based on source hash; use darker palette in light mode for contrast
+      const isDark = document.documentElement.getAttribute('data-theme') !== 'light';
+      const colors = isDark
+        ? ['#ff3333', '#ff9f43', '#00e5ff', '#ff6b35', '#a29bfe']
+        : ['#dc2626', '#d97706', '#0284c7', '#ea580c', '#7c3aed'];
       const icons = ['alert-triangle', 'cloud-lightning', 'alert-circle', 'server', 'shield-alert'];
       let hash = 0;
       for (let i = 0; i < item.source.length; i++) { hash = item.source.charCodeAt(i) + ((hash << 5) - hash); }


### PR DESCRIPTION
## Summary

- **#45 — Light mode globe**: Globe renders `earth-day.jpg` in light mode and `earth-night.jpg` in dark mode. Texture swaps immediately on runtime theme toggle (`window.applyTheme()` override). Feed source colours use a darker accessible palette in light mode (handled in JS, not overrideable CSS). Locations panel, feed items, and APT tracker borders are styled for light mode via `[data-theme="light"]` CSS rules.
- **#46 — Scroll-wheel zoom**: `enableZoom = false` → `true`. Auto-rotation and drag unchanged.
- **Dashboard — Risk score card**: Simplified to gauge only — toggle, breakdown rows, footer, and side label removed. Gauge fills card width responsively via `width:100%; aspect-ratio:1`.
- **Dashboard — Security Scanners card**: Replaced toggle+rows with a Chart.js horizontal bar chart. Only scanners with >20 findings are shown.

## Changes

| File | What changed |
|------|-------------|
| `frontend/threat-intel.html` | Theme-aware globe texture; `applyTheme()` override; light-mode CSS rules; JS-based feed-source colour palette for light mode; `enableZoom:true` |
| `frontend/index.html` | Risk card → gauge only (responsive fill); Scanners card → Chart.js horizontal bar chart filtered to >20 findings |
| `CLAUDE.md` | Updated threat-intel page description |
| `README.md` | Added Threat Intel Globe feature row |

## Notes on review comments

- **Globe textures from unpkg**: `earth-night.jpg` was already loaded from `//unpkg.com/three-globe/...` before this PR — this is the upstream globe.gl example pattern. Both textures now use the same CDN host and path structure. Vendoring is a separate improvement.
- **feed-source inline style**: Fixed — colour now applied in JS with a theme-aware palette rather than a CSS rule that can't win against inline styles.

## Test plan

- [ ] Open `/threat-intel.html` in **light mode** — globe shows day texture; feed source labels use dark readable colours; locations panel and APT tracker look clean
- [ ] Toggle to **dark mode** — globe switches to night texture immediately; all dark styles preserved
- [ ] Scroll over the globe — zoom works
- [ ] Dashboard `/` — risk card shows only gauge + label, fills card width; scanners card shows horizontal bar chart with only scanners >20 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)