### PR TITLE
feat: CVE-first findings redesign with affected repos panel

### DIFF
--- a/frontend/app-detail.html
+++ b/frontend/app-detail.html
@@ -10,6 +10,7 @@
   <link rel="stylesheet" href="/static/css/theme.css">
   <script src="/static/js/chart.min.js"></script>
   <script src="/static/js/lucide.min.js"></script>
+  <script src="/static/js/snitch-utils.js"></script>
   <style>
     * { box-sizing: border-box; }
     @keyframes slideInRight { from{transform:translateX(100px);opacity:0} to{transform:translateX(0);opacity:1} }
@@ -554,7 +555,7 @@ function renderFindingsTable(findings){
     <tr class="table-row" style="border-bottom:1px solid rgba(0,229,255,0.06);cursor:pointer;transition:background 0.2s;" id="row-${f.id}" onclick="toggleExpand('${f.id}')">
       <td style="padding:12px;">${severityBadge(f.severity)}</td>
       <td style="padding:12px;max-width:260px;">
-        <div style="font-size:15px;font-weight:500;color:#e2e8f0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;" title="${escHtml(f.title||'')}">${escHtml(f.title||'—')}</div>
+        <div style="font-size:15px;font-weight:500;color:#e2e8f0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;" title="${escHtml(humanizeTitle(f.title||''))}">${escHtml(humanizeTitle(f.title||'')||'—')}</div>
         ${f.cve_id?`<div style="font-size:13px;color:var(--text-tertiary);margin-top:2px;">${escHtml(f.cve_id)}</div>`:''}
       </td>
       <td style="padding:12px;font-size:14px;color:var(--text-secondary);">${escHtml(f.finding_type||'—')}</td>
@@ -756,7 +757,7 @@ function openRemediationModal(){
       <label style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;cursor:pointer;transition:background 0.2s;" onmouseover="this.style.background='rgba(255,255,255,0.04)'" onmouseout="this.style.background='transparent'">
         <input type="checkbox" value="${f.id}" ${isFixable(f)?'checked':''} onchange="updateRemSelCount()" style="accent-color:#00e5ff;width:16px;height:16px;cursor:pointer;">
         ${severityBadge(f.severity)}
-        <span style="font-size:15px;color:#e2e8f0;flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${escHtml(f.title||'Untitled')}</span>
+        <span style="font-size:15px;color:#e2e8f0;flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${escHtml(humanizeTitle(f.title||'Untitled'))}</span>
         ${appFixBadge(f)}
       </label>
     `).join('');
@@ -920,7 +921,7 @@ function prStateBadge(pr){
 
 function renderPRFindingRow(f){
   const alertLink=f.github_alert_url?`<a href="${escHtml(f.github_alert_url)}" target="_blank" rel="noopener" title="View on GitHub" style="flex-shrink:0;"><i data-lucide="external-link" style="width:13px;height:13px;"></i></a>`:'';
-  const findingLink=`<a href="/findings.html?identifier=${encodeURIComponent(f.rule_id||f.cve_id||'')}" title="View in Findings Hub">${escHtml(f.title)}</a>`;
+  const findingLink=`<a href="/findings.html?identifier=${encodeURIComponent(f.rule_id||f.cve_id||'')}" title="View in Findings Hub">${escHtml(humanizeTitle(f.title||''))}</a>`;
   return `<div class="finding-row">
     ${severityBadge(f.severity)}
     ${prTypeBadge(f.finding_type)}
@@ -1291,7 +1292,7 @@ function renderGithubTab(findings){
       <div style="display:flex;align-items:center;gap:10px;padding:10px 14px;border-radius:8px;transition:background 0.15s;" onmouseover="this.style.background='rgba(255,255,255,0.03)'" onmouseout="this.style.background='transparent'">
         ${severityBadge(f.severity)}
         <div style="flex:1;min-width:0;">
-          <div style="font-size:14px;font-weight:500;color:#e2e8f0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${escHtml(f.title||'—')}</div>
+          <div style="font-size:14px;font-weight:500;color:#e2e8f0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${escHtml(humanizeTitle(f.title||'')||'—')}</div>
           ${f.file_path?`<div style="font-size:12px;color:var(--text-tertiary);font-family:'Fira Code',monospace;">${escHtml(f.file_path)}${f.line_number?':'+f.line_number:''}</div>`:''}
           ${f.cve_id?`<div style="font-size:12px;color:#f59e0b;font-family:'Fira Code',monospace;">${escHtml(f.cve_id)}</div>`:''}
         </div>

--- a/frontend/findings.html
+++ b/frontend/findings.html
@@ -125,19 +125,19 @@
           </div>
         </div>
 
-        <!-- Card 3: Top Vulnerability -->
-        <div class="card" id="mc-top-vuln-card" style="padding:18px 20px;cursor:pointer;transition:border-color 0.15s;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;" onmouseover="this.style.borderColor='rgba(0,229,255,0.35)'" onmouseout="this.style.borderColor=''">
-          <div style="font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:var(--text-tertiary);margin-bottom:14px;">Top Vulnerability</div>
-          <div id="mc-top-vuln" style="color:var(--text-tertiary);font-size:13px;width:100%;">Loading…</div>
+        <!-- Card 3: Top Vulnerabilities -->
+        <div class="card" id="mc-top-vuln-card" style="padding:18px 20px;display:flex;flex-direction:column;">
+          <div style="font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:var(--text-tertiary);margin-bottom:14px;">Top Vulnerabilities</div>
+          <div id="mc-top-vuln" style="flex:1;display:flex;flex-direction:column;justify-content:space-between;color:var(--text-tertiary);font-size:13px;">Loading…</div>
         </div>
 
         <!-- Card 4: Open Findings Trend (30d) -->
-        <div class="card" style="padding:18px 20px;">
+        <div class="card" style="padding:18px 20px;display:flex;flex-direction:column;">
           <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px;">
             <div style="font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:var(--text-tertiary);">Open Findings (30d)</div>
             <span id="mc-trend-current" style="font-family:'Fira Code',monospace;font-size:18px;font-weight:700;color:var(--text-primary);line-height:1;">—</span>
           </div>
-          <div style="height:78px;position:relative;">
+          <div style="flex:1;position:relative;min-height:60px;">
             <canvas id="mc-trend-chart"></canvas>
           </div>
         </div>
@@ -327,28 +327,24 @@ async function loadTopVuln() {
     const data = await res.json();
     const allItems = data.items || [];
     if (!allItems.length) return;
-    // Restrict to CVEs only
     const items = allItems.filter(item => /^CVE-\d{4}-\d+/i.test(item.identifier));
+    const container = document.getElementById('mc-top-vuln');
+    if (!container) return;
     if (!items.length) {
-      const container = document.getElementById('mc-top-vuln');
-      if (container) container.innerHTML = `<div style="font-size:13px;color:var(--text-tertiary);">No CVEs detected</div>`;
+      container.innerHTML = `<div style="font-size:13px;color:var(--text-tertiary);">No CVEs detected</div>`;
       return;
     }
     items.sort((a, b) => b.total_occurrences - a.total_occurrences);
-    const v = items[0];
-    const isCve = /^CVE-\d{4}-\d+/i.test(v.identifier);
-    const card = document.getElementById('mc-top-vuln-card');
-    const container = document.getElementById('mc-top-vuln');
-    if (!container || !card) return;
-    container.innerHTML = `
-      <div class="cve-headline" style="font-size:22px;line-height:1.2;word-break:break-word;padding:0 4px;" title="${escapeHtml(v.identifier)}">${escapeHtml(v.identifier)}</div>
-      <div style="font-size:12px;color:var(--text-tertiary);margin-top:10px;">${v.total_occurrences} occurrences · ${v.affected_apps} app${v.affected_apps !== 1 ? 's' : ''}</div>
-    `;
-    card.dataset.identifier = v.identifier;
-    card.dataset.title      = v.title || '';
-    card.dataset.severity   = v.severity;
-    card.dataset.isCve      = isCve;
-    if (v.cvss_score != null) card.dataset.cvss = v.cvss_score;
+    const top3 = items.slice(0, 3);
+    container.innerHTML = top3.map((v, i) => {
+      const cvssAttr = v.cvss_score != null ? ` data-cvss="${v.cvss_score}"` : '';
+      const border = i < top3.length - 1 ? 'border-bottom:1px solid rgba(255,255,255,0.06);' : '';
+      return `<div class="top-vuln-row" style="display:flex;align-items:center;gap:10px;padding:${i===0?'0 0 10px':i===top3.length-1?'10px 0 0':'10px 0'};${border}cursor:pointer;transition:opacity 0.15s;" onmouseover="this.style.opacity='0.75'" onmouseout="this.style.opacity='1'"
+        data-identifier="${escapeHtml(v.identifier)}" data-title="${escapeHtml(v.title||'')}" data-severity="${escapeHtml(v.severity)}" data-is-cve="true"${cvssAttr}>
+        <span style="font-size:12px;font-weight:700;color:var(--text-tertiary);font-family:'Fira Code',monospace;width:14px;flex-shrink:0;text-align:right;">${i+1}</span>
+        <div class="cve-headline" style="font-size:14px;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;" title="${escapeHtml(v.identifier)}">${escapeHtml(v.identifier)}</div>
+      </div>`;
+    }).join('');
   } catch {}
 }
 
@@ -921,16 +917,14 @@ document.getElementById('grouped-tbody').addEventListener('click', function(e) {
   }
 });
 
-// Top-vuln card click delegation
-document.getElementById('mc-top-vuln-card').addEventListener('click', function() {
-  const ident = this.dataset.identifier;
+// Top-vulns row click delegation
+document.getElementById('mc-top-vuln').addEventListener('click', function(e) {
+  const row = e.target.closest('.top-vuln-row');
+  if (!row) return;
+  const ident = row.dataset.identifier;
   if (!ident) return;
-  if (this.dataset.isCve === 'true') {
-    const cvss = this.dataset.cvss ? parseFloat(this.dataset.cvss) : null;
-    openCvePanel(ident, this.dataset.title || '', this.dataset.severity || 'info', cvss);
-  } else {
-    drillDown(ident);
-  }
+  const cvss = row.dataset.cvss ? parseFloat(row.dataset.cvss) : null;
+  openCvePanel(ident, row.dataset.title || '', row.dataset.severity || 'info', cvss);
 });
 
 // Init

--- a/frontend/findings.html
+++ b/frontend/findings.html
@@ -52,6 +52,14 @@
     }
     .pagination-btn:hover:not(:disabled) { background: rgba(0,229,255,0.1); }
     .pagination-btn:disabled { opacity: 0.5; cursor: not-allowed; border-color: rgba(255,255,255,0.1); color:var(--text-secondary); }
+
+    .cve-headline { font-family:'Fira Code',monospace; font-size:15px; font-weight:700; color:#00e5ff; letter-spacing:0.5px; transition:color 0.15s; }
+    [data-theme="light"] .cve-headline { color:#0ea5e9; }
+    .table-row:hover .cve-headline { color:#33eeff; }
+    [data-theme="light"] .table-row:hover .cve-headline { color:#0284c7; }
+
+    #cve-panel-aside { transform:translateX(100%); transition:transform 0.3s cubic-bezier(0.4,0,0.2,1); }
+    #cve-panel.open #cve-panel-aside { transform:translateX(0); }
   </style>
 </head>
 <body style="font-family:var(--font-body,'Fira Sans',system-ui,sans-serif);background:var(--bg-page,#0a0e1a);color:var(--text-primary,#f1f5f9);margin:0;padding:0;min-height:100vh;">
@@ -164,7 +172,7 @@
             <i data-lucide="layers" style="width:16px;height:16px;color:#00e5ff;"></i>
             <span id="grouped-count">Loading…</span>
           </div>
-          <div style="font-size:13px;color:var(--text-tertiary);">Click a row to see all occurrences</div>
+          <div style="font-size:13px;color:var(--text-tertiary);">CVE rows open affected repos panel · others show all occurrences</div>
         </div>
         <div style="overflow-x:auto;">
           <table style="width:100%;border-collapse:collapse;">
@@ -286,18 +294,29 @@ async function loadGrouped() {
     tbody.innerHTML = items.map(v => {
       const eh = escapeHtml;
       const rawIdent = v.identifier || '—';
-      const ident = eh(rawIdent);
-      const title = eh((v.title||'Unknown').slice(0,65)) + ((v.title||'').length>65?'…':'');
+      const isCve = /^CVE-\d{4}-\d+/i.test(rawIdent);
+
+      const primaryHtml = isCve
+        ? `<div class="cve-headline" style="white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${eh(rawIdent)}</div>`
+        : `<div style="font-size:14px;font-weight:600;color:var(--text-primary);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${eh((v.title||'Unknown').slice(0,65))}${(v.title||'').length>65?'…':''}</div>`;
+
+      const secondaryHtml = isCve
+        ? `<div style="font-size:12px;color:var(--text-tertiary);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;margin-top:2px;">${eh((v.title||'').slice(0,65))}${(v.title||'').length>65?'…':''}</div>`
+        : `<div style="font-size:12px;color:var(--text-tertiary);font-family:'Fira Code',monospace;margin-top:2px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${eh(rawIdent)}</div>`;
+
       const fix = v.fix_available
         ? (v.fixed_version
             ? `<span style="background:rgba(16,185,129,0.1);color:#10b981;border:1px solid rgba(16,185,129,0.25);padding:2px 7px;border-radius:5px;font-size:12px;font-weight:600;" title="${eh(v.fixed_version)}">✓ ${eh(v.fixed_version)}</span>`
             : `<span style="background:rgba(16,185,129,0.08);color:#10b981;border:1px solid rgba(16,185,129,0.18);padding:2px 7px;border-radius:5px;font-size:12px;font-weight:600;">✓ Available</span>`)
         : `<span style="background:rgba(148,163,184,0.08);color:#64748b;border:1px solid rgba(148,163,184,0.15);padding:2px 7px;border-radius:5px;font-size:12px;font-weight:500;">No Fix Yet</span>`;
-      return `<tr class="table-row" style="border-bottom:1px solid rgba(255,255,255,0.04);" onclick="drillDown(${JSON.stringify(rawIdent)})">
+
+      // Use data-* attributes to avoid onclick HTML-escaping issues with quoted strings
+      const cvssAttr = v.cvss_score != null ? ` data-cvss="${v.cvss_score}"` : '';
+      return `<tr class="table-row" style="border-bottom:1px solid rgba(255,255,255,0.04);" data-identifier="${eh(rawIdent)}" data-title="${eh(v.title||'')}" data-severity="${eh(v.severity)}" data-is-cve="${isCve}"${cvssAttr}>
         <td style="padding:12px 20px;">${severityBadge(v.severity)}</td>
         <td style="padding:12px 20px;max-width:380px;">
-          <div style="font-size:14px;font-weight:600;color:var(--text-primary);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${title}</div>
-          <div style="font-size:12px;color:var(--text-tertiary);font-family:'Fira Code',monospace;margin-top:2px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${ident}</div>
+          ${primaryHtml}
+          ${secondaryHtml}
         </td>
         <td style="padding:12px 20px;">${typeBadge(v.finding_type)}</td>
         <td style="padding:12px 20px;">${fix}</td>
@@ -355,6 +374,15 @@ function fixBadge(f){
   if(['sca','container'].includes(ft))
     return `<span style="background:rgba(148,163,184,0.08);color:#64748b;border:1px solid rgba(148,163,184,0.15);padding:2px 8px;border-radius:5px;font-size:12px;font-weight:500;">No Fix Yet</span>`;
   return `<span style="background:rgba(16,185,129,0.08);color:#10b981;border:1px solid rgba(16,185,129,0.18);padding:2px 8px;border-radius:5px;font-size:12px;font-weight:600;">✓ Available</span>`;
+}
+
+function findingTitleCell(f) {
+  const eh = escapeHtml;
+  if (f.cve_id) {
+    return `<div class="cve-headline" style="white-space:nowrap;overflow:hidden;text-overflow:ellipsis;" title="${eh(f.cve_id)}">${eh(f.cve_id)}</div>
+            <div style="font-size:12px;color:var(--text-tertiary);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;margin-top:2px;" title="${eh(f.title||'')}">${eh((f.title||'').slice(0,60))}${(f.title||'').length>60?'…':''}</div>`;
+  }
+  return `<div style="font-size:15px;font-weight:600;color:var(--text-primary);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;" title="${eh(f.title||'')}">${eh((f.title||'Unknown').slice(0,60))}${(f.title||'').length>60?'…':''}</div>`;
 }
 
 function timeAgo(dateStr) {
@@ -434,9 +462,7 @@ async function loadFindings() {
     tbody.innerHTML = data.items.map(f => `
       <tr class="table-row" style="border-bottom:1px solid rgba(255,255,255,0.04);" onclick="openFindingPanel('${escapeHtml(f.id)}')">
         <td style="padding:16px 24px;">${severityBadge(f.severity)}</td>
-        <td style="padding:16px 24px;max-width:350px;">
-          <div style="font-size:15px;font-weight:600;color:var(--text-primary);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;" title="${escapeHtml(f.title||'')}">${escapeHtml((f.title||'Unknown').slice(0,60))}${(f.title||'').length>60?'…':''}</div>
-        </td>
+        <td style="padding:16px 24px;max-width:350px;">${findingTitleCell(f)}</td>
         <td style="padding:16px 24px;">
           <div style="font-size:14px;color:var(--text-primary);font-weight:500;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:200px;" title="${escapeHtml(f.application_name||f.application_id)}">${escapeHtml(f.application_name||f.application_id.split('-')[0]+'...')}</div>
         </td>
@@ -517,6 +543,86 @@ function closeFindingPanel() {
   setTimeout(() => { panel.style.display = 'none'; activeFindingId = null; }, 300);
 }
 
+// ── CVE Affected Apps Panel ──────────────────────────────────────────────────
+function closeCvePanel() {
+  const panel = document.getElementById('cve-panel');
+  panel.classList.remove('open');
+  setTimeout(() => { panel.style.display = 'none'; }, 300);
+}
+
+async function openCvePanel(identifier, title, severity, cvssScore) {
+  const panel      = document.getElementById('cve-panel');
+  const panelBody  = document.getElementById('cve-panel-body');
+  const panelTitle = document.getElementById('cve-panel-title');
+
+  panelTitle.textContent = identifier;
+
+  const cvssHtml = cvssScore != null
+    ? `<span style="font-family:'Fira Code',monospace;font-size:14px;color:var(--text-secondary);">CVSS ${Number(cvssScore).toFixed(1)}</span>`
+    : '';
+
+  panelBody.innerHTML = `
+    <div style="padding:24px;display:flex;flex-direction:column;gap:20px;">
+      <div>
+        <div style="font-size:26px;font-weight:700;font-family:'Fira Code',monospace;color:#00e5ff;letter-spacing:0.5px;word-break:break-all;">${escapeHtml(identifier)}</div>
+        <div style="margin-top:8px;display:flex;align-items:center;gap:10px;flex-wrap:wrap;">
+          ${severityBadge(severity)}
+          ${cvssHtml}
+        </div>
+      </div>
+      ${title ? `<div style="font-size:14px;color:var(--text-secondary);line-height:1.5;">${escapeHtml(title)}</div>` : ''}
+      <div>
+        <div style="font-size:12px;font-weight:600;color:var(--text-tertiary);text-transform:uppercase;letter-spacing:1px;margin-bottom:10px;">Affected Repositories</div>
+        <div id="cve-apps-list">
+          <div style="display:flex;justify-content:center;padding:24px;">
+            <div style="animation:spin 1s linear infinite;width:24px;height:24px;border:3px solid rgba(0,229,255,0.1);border-top-color:#00e5ff;border-radius:50%;"></div>
+          </div>
+        </div>
+      </div>
+      <button onclick="drillDown(${JSON.stringify(identifier)});closeCvePanel();" style="display:inline-flex;align-items:center;gap:6px;background:rgba(0,229,255,0.08);border:1px solid rgba(0,229,255,0.2);color:#00e5ff;padding:8px 16px;border-radius:8px;font-size:14px;font-weight:600;cursor:pointer;transition:background 0.15s;" onmouseover="this.style.background='rgba(0,229,255,0.16)'" onmouseout="this.style.background='rgba(0,229,255,0.08)'">
+        View all findings →
+      </button>
+    </div>
+  `;
+
+  panel.style.display = 'flex';
+  requestAnimationFrame(() => requestAnimationFrame(() => panel.classList.add('open')));
+  lucide.createIcons();
+
+  try {
+    const res = await fetch(`/api/v1/findings?identifier=${encodeURIComponent(identifier)}&page_size=100`);
+    if (!res.ok) throw new Error();
+    const data = await res.json();
+    const items = data.items || [];
+
+    const seen = new Set();
+    const apps = [];
+    for (const f of items) {
+      if (f.application_id && !seen.has(f.application_id)) {
+        seen.add(f.application_id);
+        apps.push({ id: f.application_id, name: f.application_name || f.application_id });
+      }
+    }
+
+    const appsList = document.getElementById('cve-apps-list');
+    if (!appsList) return;
+    if (!apps.length) {
+      appsList.innerHTML = `<div style="font-size:14px;color:var(--text-tertiary);padding:8px 0;">No affected applications found.</div>`;
+    } else {
+      appsList.innerHTML = apps.map(a => `
+        <a href="/app-detail.html?id=${escapeHtml(a.id)}" style="display:flex;align-items:center;gap:8px;padding:10px 14px;border-radius:8px;background:rgba(0,229,255,0.04);border:1px solid rgba(0,229,255,0.1);color:var(--text-primary);text-decoration:none;font-size:14px;font-weight:500;margin-bottom:6px;transition:background 0.15s;" onmouseover="this.style.background='rgba(0,229,255,0.1)'" onmouseout="this.style.background='rgba(0,229,255,0.04)'">
+          <i data-lucide="git-fork" style="width:14px;height:14px;color:#00e5ff;flex-shrink:0;"></i>
+          ${escapeHtml(a.name)}
+        </a>
+      `).join('');
+      lucide.createIcons();
+    }
+  } catch {
+    const appsList = document.getElementById('cve-apps-list');
+    if (appsList) appsList.innerHTML = `<div style="font-size:14px;color:#ef4444;">Failed to load affected applications.</div>`;
+  }
+}
+
 function renderPanel(f) {
   const body = document.getElementById('panel-body');
   const eh = escapeHtml;
@@ -526,6 +632,11 @@ function renderPanel(f) {
         ${severityBadge(f.severity)}
         ${typeBadge(f.finding_type||f.scanner)}
       </div>
+      ${f.cve_id ? `
+      <div style="padding:14px 18px;background:rgba(0,229,255,0.05);border:1px solid rgba(0,229,255,0.2);border-radius:10px;display:flex;align-items:center;gap:16px;flex-wrap:wrap;">
+        <div style="font-size:22px;font-weight:700;font-family:'Fira Code',monospace;color:var(--accent,#00e5ff);letter-spacing:0.5px;">${eh(f.cve_id)}</div>
+        ${f.cvss_score != null ? `<div style="font-size:13px;color:var(--text-secondary);font-family:'Fira Code',monospace;border-left:1px solid rgba(0,229,255,0.2);padding-left:16px;">CVSS ${f.cvss_score.toFixed(1)}</div>` : ''}
+      </div>` : ''}
       <div>
         <div style="font-size:13px;font-weight:600;color:var(--text-tertiary);text-transform:uppercase;letter-spacing:1px;margin-bottom:6px;">Title</div>
         <div style="font-size:16px;font-weight:600;color:var(--text-primary);line-height:1.4;">${eh(f.title)||'—'}</div>
@@ -549,17 +660,12 @@ function renderPanel(f) {
           <div style="font-size:12px;font-weight:600;color:var(--text-tertiary);text-transform:uppercase;letter-spacing:1px;margin-bottom:4px;">File Path</div>
           <div style="font-size:13px;color:var(--text-secondary);font-family:'Fira Code',monospace;word-break:break-all;">${eh(f.file_path)}${f.line_number ? ':'+f.line_number : ''}</div>
         </div>` : ''}
-        ${f.cve_id ? `
-        <div>
-          <div style="font-size:12px;font-weight:600;color:var(--text-tertiary);text-transform:uppercase;letter-spacing:1px;margin-bottom:4px;">CVE</div>
-          <div style="font-size:14px;color:var(--text-primary);font-family:'Fira Code',monospace;">${eh(f.cve_id)}</div>
-        </div>` : ''}
         ${f.package_name ? `
         <div>
           <div style="font-size:12px;font-weight:600;color:var(--text-tertiary);text-transform:uppercase;letter-spacing:1px;margin-bottom:4px;">Package</div>
           <div style="font-size:14px;color:var(--text-primary);font-family:'Fira Code',monospace;">${eh(f.package_name)}${f.package_version?' @ '+eh(f.package_version):''}</div>
         </div>` : ''}
-        ${f.cvss_score != null ? `
+        ${f.cvss_score != null && !f.cve_id ? `
         <div>
           <div style="font-size:12px;font-weight:600;color:var(--text-tertiary);text-transform:uppercase;letter-spacing:1px;margin-bottom:4px;">CVSS Score</div>
           <div style="font-size:14px;color:var(--text-primary);font-family:'Fira Code',monospace;">${f.cvss_score.toFixed(1)}</div>
@@ -640,7 +746,21 @@ async function updateFindingStatus(id, status) {
   }
 }
 
-document.addEventListener('keydown', e => { if (e.key === 'Escape') closeFindingPanel(); });
+document.addEventListener('keydown', e => { if (e.key === 'Escape') { closeFindingPanel(); closeCvePanel(); } });
+
+// Grouped table click delegation — avoids inline onclick HTML-escaping issues
+document.getElementById('grouped-tbody').addEventListener('click', function(e) {
+  const row = e.target.closest('tr[data-identifier]');
+  if (!row) return;
+  const ident = row.dataset.identifier;
+  if (!ident || ident === '—') return;
+  if (row.dataset.isCve === 'true') {
+    const cvss = row.dataset.cvss ? parseFloat(row.dataset.cvss) : null;
+    openCvePanel(ident, row.dataset.title || '', row.dataset.severity || 'info', cvss);
+  } else {
+    drillDown(ident);
+  }
+});
 
 // Init
 parseQueryParams();
@@ -672,6 +792,18 @@ if (_initIdentifier) {
     <div id="panel-body" style="flex:1;overflow-y:auto;"></div>
   </aside>
 </div>
+<!-- CVE Affected Apps Panel -->
+<div id="cve-panel" style="display:none;position:fixed;inset:0;z-index:201;justify-content:flex-end;">
+  <div onclick="closeCvePanel()" style="position:absolute;inset:0;background:rgba(0,0,0,0.5);backdrop-filter:blur(2px);"></div>
+  <aside id="cve-panel-aside" style="position:relative;width:440px;max-width:95vw;height:100%;background:linear-gradient(180deg,#0f1b34 0%,#080f1d 100%);border-left:1px solid rgba(0,229,255,0.15);box-shadow:-8px 0 48px rgba(0,0,0,0.7);display:flex;flex-direction:column;">
+    <div style="padding:16px 24px;border-bottom:1px solid rgba(0,229,255,0.1);display:flex;align-items:center;justify-content:space-between;background:rgba(0,0,0,0.2);">
+      <div id="cve-panel-title" style="font-size:15px;font-weight:700;color:#00e5ff;font-family:'Fira Code',monospace;">CVE Detail</div>
+      <button onclick="closeCvePanel()" style="background:none;border:none;color:var(--text-secondary);cursor:pointer;padding:4px;border-radius:6px;display:flex;align-items:center;" onmouseover="this.style.color='#f1f5f9'" onmouseout="this.style.color='#94a3b8'"><i data-lucide="x" style="width:20px;height:20px;"></i></button>
+    </div>
+    <div id="cve-panel-body" style="flex:1;overflow-y:auto;"></div>
+  </aside>
+</div>
+
 <style>
 #panel-aside { transform: translateX(100%); transition: transform 0.3s cubic-bezier(0.4,0,0.2,1); }
 #finding-panel.open #panel-aside { transform: translateX(0); }

--- a/frontend/findings.html
+++ b/frontend/findings.html
@@ -453,8 +453,9 @@ async function loadGrouped() {
         ? `<div class="cve-headline" style="white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${eh(rawIdent)}</div>`
         : `<div style="font-size:14px;font-weight:600;color:var(--text-primary);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${eh(_htitle.slice(0,65))}${_htitle.length>65?'…':''}</div>`;
 
+      const _hsecondary = humanizeTitle(v.title || '');
       const secondaryHtml = isCve
-        ? `<div style="font-size:12px;color:var(--text-tertiary);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;margin-top:2px;">${eh(humanizeTitle(v.title||'').slice(0,65))}${(v.title||'').length>65?'…':''}</div>`
+        ? `<div style="font-size:12px;color:var(--text-tertiary);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;margin-top:2px;">${eh(_hsecondary.slice(0,65))}${_hsecondary.length>65?'…':''}</div>`
         : `<div style="font-size:12px;color:var(--text-tertiary);font-family:'Fira Code',monospace;margin-top:2px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${eh(rawIdent)}</div>`;
 
       const fix = v.fix_available
@@ -734,7 +735,7 @@ async function openCvePanel(identifier, title, severity, cvssScore) {
           </div>
         </div>
       </div>
-      <button onclick="drillDown(${JSON.stringify(identifier)});closeCvePanel();" style="display:inline-flex;align-items:center;gap:6px;background:rgba(0,229,255,0.08);border:1px solid rgba(0,229,255,0.2);color:#00e5ff;padding:8px 16px;border-radius:8px;font-size:14px;font-weight:600;cursor:pointer;transition:background 0.15s;" onmouseover="this.style.background='rgba(0,229,255,0.16)'" onmouseout="this.style.background='rgba(0,229,255,0.08)'">
+      <button id="cve-drilldown-btn" data-identifier="${escapeHtml(identifier)}" style="display:inline-flex;align-items:center;gap:6px;background:rgba(0,229,255,0.08);border:1px solid rgba(0,229,255,0.2);color:#00e5ff;padding:8px 16px;border-radius:8px;font-size:14px;font-weight:600;cursor:pointer;transition:background 0.15s;" onmouseover="this.style.background='rgba(0,229,255,0.16)'" onmouseout="this.style.background='rgba(0,229,255,0.08)'">
         View all findings →
       </button>
     </div>
@@ -915,6 +916,14 @@ document.getElementById('grouped-tbody').addEventListener('click', function(e) {
   } else {
     drillDown(ident);
   }
+});
+
+// CVE panel "View all findings" button delegation — avoids JSON.stringify in onclick=""
+document.addEventListener('click', function(e) {
+  const btn = e.target.closest('#cve-drilldown-btn');
+  if (!btn) return;
+  const ident = btn.dataset.identifier;
+  if (ident) { drillDown(ident); closeCvePanel(); }
 });
 
 // Top-vulns row click delegation

--- a/frontend/findings.html
+++ b/frontend/findings.html
@@ -90,20 +90,29 @@
       <div id="metric-cards" style="display:grid;grid-template-columns:repeat(4,1fr);gap:14px;margin-bottom:20px;">
 
         <!-- Card 1: Findings Breakdown -->
-        <div class="card" style="padding:18px 20px;">
-          <div style="font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:var(--text-tertiary);margin-bottom:10px;">Findings Breakdown</div>
-          <div style="display:flex;flex-direction:column;gap:8px;">
-            <div style="display:flex;justify-content:space-between;align-items:center;">
-              <span style="font-size:12px;font-weight:600;color:#ef4444;">Critical</span>
-              <span id="mc-critical" style="font-family:'Fira Code',monospace;font-size:20px;font-weight:700;color:#ef4444;line-height:1;">—</span>
+        <div class="card" style="padding:18px 20px;display:flex;flex-direction:column;">
+          <div style="font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:var(--text-tertiary);margin-bottom:14px;">Findings Breakdown</div>
+          <div style="display:flex;flex-direction:column;flex:1;justify-content:space-between;">
+            <div style="display:flex;justify-content:space-between;align-items:center;padding-bottom:10px;border-bottom:1px solid rgba(239,68,68,0.12);">
+              <div style="display:flex;align-items:center;gap:8px;">
+                <div style="width:3px;height:18px;background:#ef4444;border-radius:2px;flex-shrink:0;"></div>
+                <span style="font-size:14px;font-weight:600;color:#ef4444;">Critical</span>
+              </div>
+              <span id="mc-critical" style="font-family:'Fira Code',monospace;font-size:28px;font-weight:700;color:#ef4444;line-height:1;">—</span>
             </div>
-            <div style="display:flex;justify-content:space-between;align-items:center;">
-              <span style="font-size:12px;font-weight:600;color:#f59e0b;">High</span>
-              <span id="mc-high" style="font-family:'Fira Code',monospace;font-size:20px;font-weight:700;color:#f59e0b;line-height:1;">—</span>
+            <div style="display:flex;justify-content:space-between;align-items:center;padding:10px 0;border-bottom:1px solid rgba(245,158,11,0.12);">
+              <div style="display:flex;align-items:center;gap:8px;">
+                <div style="width:3px;height:18px;background:#f59e0b;border-radius:2px;flex-shrink:0;"></div>
+                <span style="font-size:14px;font-weight:600;color:#f59e0b;">High</span>
+              </div>
+              <span id="mc-high" style="font-family:'Fira Code',monospace;font-size:28px;font-weight:700;color:#f59e0b;line-height:1;">—</span>
             </div>
-            <div style="display:flex;justify-content:space-between;align-items:center;">
-              <span style="font-size:12px;font-weight:600;color:#f97316;">Medium</span>
-              <span id="mc-medium" style="font-family:'Fira Code',monospace;font-size:20px;font-weight:700;color:#f97316;line-height:1;">—</span>
+            <div style="display:flex;justify-content:space-between;align-items:center;padding-top:10px;">
+              <div style="display:flex;align-items:center;gap:8px;">
+                <div style="width:3px;height:18px;background:#f97316;border-radius:2px;flex-shrink:0;"></div>
+                <span style="font-size:14px;font-weight:600;color:#f97316;">Medium</span>
+              </div>
+              <span id="mc-medium" style="font-family:'Fira Code',monospace;font-size:28px;font-weight:700;color:#f97316;line-height:1;">—</span>
             </div>
           </div>
         </div>
@@ -117,9 +126,9 @@
         </div>
 
         <!-- Card 3: Top Vulnerability -->
-        <div class="card" id="mc-top-vuln-card" style="padding:18px 20px;cursor:pointer;transition:border-color 0.15s;" onmouseover="this.style.borderColor='rgba(0,229,255,0.35)'" onmouseout="this.style.borderColor=''">
-          <div style="font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:var(--text-tertiary);margin-bottom:10px;">Top Vulnerability</div>
-          <div id="mc-top-vuln" style="color:var(--text-tertiary);font-size:13px;">Loading…</div>
+        <div class="card" id="mc-top-vuln-card" style="padding:18px 20px;cursor:pointer;transition:border-color 0.15s;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;" onmouseover="this.style.borderColor='rgba(0,229,255,0.35)'" onmouseout="this.style.borderColor=''">
+          <div style="font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:var(--text-tertiary);margin-bottom:14px;">Top Vulnerability</div>
+          <div id="mc-top-vuln" style="color:var(--text-tertiary);font-size:13px;width:100%;">Loading…</div>
         </div>
 
         <!-- Card 4: Open Findings Trend (30d) -->
@@ -332,8 +341,8 @@ async function loadTopVuln() {
     const container = document.getElementById('mc-top-vuln');
     if (!container || !card) return;
     container.innerHTML = `
-      <div class="cve-headline" style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-size:14px;" title="${escapeHtml(v.identifier)}">${escapeHtml(v.identifier)}</div>
-      <div style="font-size:12px;color:var(--text-tertiary);margin-top:5px;">${v.total_occurrences} occurrences · ${v.affected_apps} app${v.affected_apps !== 1 ? 's' : ''}</div>
+      <div class="cve-headline" style="font-size:22px;line-height:1.2;word-break:break-word;padding:0 4px;" title="${escapeHtml(v.identifier)}">${escapeHtml(v.identifier)}</div>
+      <div style="font-size:12px;color:var(--text-tertiary);margin-top:10px;">${v.total_occurrences} occurrences · ${v.affected_apps} app${v.affected_apps !== 1 ? 's' : ''}</div>
     `;
     card.dataset.identifier = v.identifier;
     card.dataset.title      = v.title || '';

--- a/frontend/findings.html
+++ b/frontend/findings.html
@@ -9,6 +9,7 @@
   <style>/* Inter font fallback */ body { font-family: var(--font-body); }</style>
   <link rel="stylesheet" href="/static/css/theme.css">
   <script src="/static/js/lucide.min.js"></script>
+  <script src="/static/js/chart.min.js"></script>
   <style>
     * { box-sizing: border-box; }
     @keyframes slideInRight { from{transform:translateX(100px);opacity:0} to{transform:translateX(0);opacity:1} }
@@ -86,26 +87,51 @@
 
       <!-- ── Metric Cards ── -->
       <div id="metric-cards" style="display:grid;grid-template-columns:repeat(4,1fr);gap:14px;margin-bottom:20px;">
+
+        <!-- Card 1: Findings Breakdown -->
         <div class="card" style="padding:18px 20px;">
-          <div style="font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:var(--text-tertiary);margin-bottom:6px;">Critical Open</div>
-          <div id="mc-critical" style="font-family:'Fira Code',monospace;font-size:32px;font-weight:700;color:#ef4444;line-height:1;">—</div>
-          <div style="font-size:12px;color:var(--text-tertiary);margin-top:4px;">findings</div>
+          <div style="font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:var(--text-tertiary);margin-bottom:10px;">Findings Breakdown</div>
+          <div style="display:flex;flex-direction:column;gap:8px;">
+            <div style="display:flex;justify-content:space-between;align-items:center;">
+              <span style="font-size:12px;font-weight:600;color:#ef4444;">Critical</span>
+              <span id="mc-critical" style="font-family:'Fira Code',monospace;font-size:20px;font-weight:700;color:#ef4444;line-height:1;">—</span>
+            </div>
+            <div style="display:flex;justify-content:space-between;align-items:center;">
+              <span style="font-size:12px;font-weight:600;color:#f59e0b;">High</span>
+              <span id="mc-high" style="font-family:'Fira Code',monospace;font-size:20px;font-weight:700;color:#f59e0b;line-height:1;">—</span>
+            </div>
+            <div style="display:flex;justify-content:space-between;align-items:center;">
+              <span style="font-size:12px;font-weight:600;color:#f97316;">Medium</span>
+              <span id="mc-medium" style="font-family:'Fira Code',monospace;font-size:20px;font-weight:700;color:#f97316;line-height:1;">—</span>
+            </div>
+          </div>
         </div>
+
+        <!-- Card 2: Top Risky Apps -->
         <div class="card" style="padding:18px 20px;">
-          <div style="font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:var(--text-tertiary);margin-bottom:6px;">High Open</div>
-          <div id="mc-high" style="font-family:'Fira Code',monospace;font-size:32px;font-weight:700;color:#f59e0b;line-height:1;">—</div>
-          <div style="font-size:12px;color:var(--text-tertiary);margin-top:4px;">findings</div>
+          <div style="font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:var(--text-tertiary);margin-bottom:10px;">Top Risky Apps</div>
+          <div id="mc-top-apps" style="display:flex;flex-direction:column;gap:8px;">
+            <div style="font-size:13px;color:var(--text-tertiary);">Loading…</div>
+          </div>
         </div>
+
+        <!-- Card 3: Top Vulnerability -->
+        <div class="card" id="mc-top-vuln-card" style="padding:18px 20px;cursor:pointer;transition:border-color 0.15s;" onmouseover="this.style.borderColor='rgba(0,229,255,0.35)'" onmouseout="this.style.borderColor=''">
+          <div style="font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:var(--text-tertiary);margin-bottom:10px;">Top Vulnerability</div>
+          <div id="mc-top-vuln" style="color:var(--text-tertiary);font-size:13px;">Loading…</div>
+        </div>
+
+        <!-- Card 4: Open Findings Trend (30d) -->
         <div class="card" style="padding:18px 20px;">
-          <div style="font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:var(--text-tertiary);margin-bottom:6px;">Total Open</div>
-          <div id="mc-open" style="font-family:'Fira Code',monospace;font-size:32px;font-weight:700;color:var(--text-primary);line-height:1;">—</div>
-          <div style="font-size:12px;color:var(--text-tertiary);margin-top:4px;">findings</div>
+          <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px;">
+            <div style="font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:var(--text-tertiary);">Open Findings (30d)</div>
+            <span id="mc-trend-current" style="font-family:'Fira Code',monospace;font-size:18px;font-weight:700;color:var(--text-primary);line-height:1;">—</span>
+          </div>
+          <div style="height:64px;position:relative;">
+            <canvas id="mc-trend-chart"></canvas>
+          </div>
         </div>
-        <div class="card" style="padding:18px 20px;">
-          <div style="font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:var(--text-tertiary);margin-bottom:6px;">Unique Vulns</div>
-          <div id="mc-unique" style="font-family:'Fira Code',monospace;font-size:32px;font-weight:700;color:#00e5ff;line-height:1;">—</div>
-          <div style="font-size:12px;color:var(--text-tertiary);margin-top:4px;">distinct identifiers</div>
-        </div>
+
       </div>
 
       <!-- Filters -->
@@ -255,8 +281,91 @@ async function loadMetrics() {
     if (!res.ok) return;
     const d = await res.json();
     document.getElementById('mc-critical').textContent = (d.critical_findings||0).toLocaleString();
-    document.getElementById('mc-high').textContent = (d.high_findings||0).toLocaleString();
-    document.getElementById('mc-open').textContent = (d.open_findings||0).toLocaleString();
+    document.getElementById('mc-high').textContent     = (d.high_findings||0).toLocaleString();
+    document.getElementById('mc-medium').textContent   = (d.medium_findings||0).toLocaleString();
+  } catch {}
+}
+
+async function loadTopApps() {
+  try {
+    const res = await fetch('/api/v1/applications?page_size=3');
+    if (!res.ok) return;
+    const data = await res.json();
+    const apps = data.items || [];
+    const container = document.getElementById('mc-top-apps');
+    if (!container) return;
+    if (!apps.length) { container.innerHTML = `<div style="font-size:13px;color:var(--text-tertiary);">No apps found.</div>`; return; }
+    const riskColor = s => s >= 75 ? '#ef4444' : s >= 50 ? '#f59e0b' : s >= 25 ? '#f97316' : '#3b82f6';
+    container.innerHTML = apps.map(a => `
+      <a href="/app-detail.html?id=${escapeHtml(a.id)}" style="display:flex;justify-content:space-between;align-items:center;text-decoration:none;gap:8px;transition:opacity 0.15s;" onmouseover="this.style.opacity='0.7'" onmouseout="this.style.opacity='1'">
+        <span style="font-size:13px;color:var(--text-primary);font-weight:500;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${escapeHtml(a.name)}</span>
+        <span style="font-family:'Fira Code',monospace;font-size:14px;font-weight:700;color:${riskColor(a.risk_score)};flex-shrink:0;">${Math.round(a.risk_score)}</span>
+      </a>
+    `).join('');
+  } catch {}
+}
+
+async function loadTopVuln() {
+  try {
+    const res = await fetch('/api/v1/reports/top-vulnerabilities?limit=200');
+    if (!res.ok) return;
+    const data = await res.json();
+    const items = data.items || [];
+    if (!items.length) return;
+    items.sort((a, b) => b.total_occurrences - a.total_occurrences);
+    const v = items[0];
+    const isCve = /^CVE-\d{4}-\d+/i.test(v.identifier);
+    const card = document.getElementById('mc-top-vuln-card');
+    const container = document.getElementById('mc-top-vuln');
+    if (!container || !card) return;
+    container.innerHTML = `
+      <div class="cve-headline" style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-size:14px;" title="${escapeHtml(v.identifier)}">${escapeHtml(v.identifier)}</div>
+      <div style="font-size:12px;color:var(--text-tertiary);margin-top:5px;">${v.total_occurrences} occurrences · ${v.affected_apps} app${v.affected_apps !== 1 ? 's' : ''}</div>
+    `;
+    card.dataset.identifier = v.identifier;
+    card.dataset.title      = v.title || '';
+    card.dataset.severity   = v.severity;
+    card.dataset.isCve      = isCve;
+    if (v.cvss_score != null) card.dataset.cvss = v.cvss_score;
+  } catch {}
+}
+
+async function loadTrendMiniChart() {
+  try {
+    const res = await fetch('/api/v1/reports/trend?days=30&cumulative=true&mode=status');
+    if (!res.ok) return;
+    const data = await res.json();
+    const points = data.data_points || [];
+    if (!points.length) return;
+    const values = points.map(p => p.open);
+    const el = document.getElementById('mc-trend-current');
+    if (el) el.textContent = (values[values.length - 1] || 0).toLocaleString();
+    const canvas = document.getElementById('mc-trend-chart');
+    if (!canvas) return;
+    if (window._mcTrendChart) window._mcTrendChart.destroy();
+    const isDark = document.documentElement.getAttribute('data-theme') !== 'light';
+    window._mcTrendChart = new Chart(canvas.getContext('2d'), {
+      type: 'line',
+      data: {
+        labels: points.map(p => p.date),
+        datasets: [{
+          data: values,
+          borderColor: isDark ? '#00e5ff' : '#0ea5e9',
+          borderWidth: 2,
+          fill: true,
+          backgroundColor: isDark ? 'rgba(0,229,255,0.08)' : 'rgba(14,165,233,0.08)',
+          pointRadius: 0,
+          tension: 0.4
+        }]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: { legend: { display: false }, tooltip: { enabled: false } },
+        scales: { x: { display: false }, y: { display: false } },
+        animation: { duration: 600 }
+      }
+    });
   } catch {}
 }
 
@@ -283,7 +392,6 @@ async function loadGrouped() {
     const items = data.items || [];
 
     document.getElementById('grouped-count').textContent = `${items.length.toLocaleString()} unique vulnerabilities`;
-    document.getElementById('mc-unique').textContent = items.length.toLocaleString();
 
     if (!items.length) {
       tbody.innerHTML = `<tr><td colspan="6" style="padding:48px;text-align:center;color:var(--text-tertiary);"><i data-lucide="shield-check" style="width:36px;height:36px;display:block;margin:0 auto 10px;opacity:0.3;"></i>No vulnerabilities match your criteria.</td></tr>`;
@@ -762,9 +870,24 @@ document.getElementById('grouped-tbody').addEventListener('click', function(e) {
   }
 });
 
+// Top-vuln card click delegation
+document.getElementById('mc-top-vuln-card').addEventListener('click', function() {
+  const ident = this.dataset.identifier;
+  if (!ident) return;
+  if (this.dataset.isCve === 'true') {
+    const cvss = this.dataset.cvss ? parseFloat(this.dataset.cvss) : null;
+    openCvePanel(ident, this.dataset.title || '', this.dataset.severity || 'info', cvss);
+  } else {
+    drillDown(ident);
+  }
+});
+
 // Init
 parseQueryParams();
 loadMetrics();
+loadTopApps();
+loadTopVuln();
+loadTrendMiniChart();
 
 // If URL has an identifier param, jump straight to all-findings view
 const _initIdentifier = new URLSearchParams(window.location.search).get('identifier');

--- a/frontend/findings.html
+++ b/frontend/findings.html
@@ -10,6 +10,7 @@
   <link rel="stylesheet" href="/static/css/theme.css">
   <script src="/static/js/lucide.min.js"></script>
   <script src="/static/js/chart.min.js"></script>
+  <script src="/static/js/snitch-utils.js"></script>
   <style>
     * { box-sizing: border-box; }
     @keyframes slideInRight { from{transform:translateX(100px);opacity:0} to{transform:translateX(0);opacity:1} }
@@ -127,7 +128,7 @@
             <div style="font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:var(--text-tertiary);">Open Findings (30d)</div>
             <span id="mc-trend-current" style="font-family:'Fira Code',monospace;font-size:18px;font-weight:700;color:var(--text-primary);line-height:1;">—</span>
           </div>
-          <div style="height:64px;position:relative;">
+          <div style="height:78px;position:relative;">
             <canvas id="mc-trend-chart"></canvas>
           </div>
         </div>
@@ -296,12 +297,17 @@ async function loadTopApps() {
     if (!container) return;
     if (!apps.length) { container.innerHTML = `<div style="font-size:13px;color:var(--text-tertiary);">No apps found.</div>`; return; }
     const riskColor = s => s >= 75 ? '#ef4444' : s >= 50 ? '#f59e0b' : s >= 25 ? '#f97316' : '#3b82f6';
-    container.innerHTML = apps.map(a => `
-      <a href="/app-detail.html?id=${escapeHtml(a.id)}" style="display:flex;justify-content:space-between;align-items:center;text-decoration:none;gap:8px;transition:opacity 0.15s;" onmouseover="this.style.opacity='0.7'" onmouseout="this.style.opacity='1'">
-        <span style="font-size:13px;color:var(--text-primary);font-weight:500;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${escapeHtml(a.name)}</span>
-        <span style="font-family:'Fira Code',monospace;font-size:14px;font-weight:700;color:${riskColor(a.risk_score)};flex-shrink:0;">${Math.round(a.risk_score)}</span>
-      </a>
-    `).join('');
+    container.innerHTML = apps.map(a => {
+      const repo = (a.github_org && a.github_repo) ? `${a.github_org}/${a.github_repo}` : '';
+      return `
+      <a href="/app-detail.html?id=${escapeHtml(a.id)}" style="display:flex;flex-direction:column;text-decoration:none;gap:1px;transition:opacity 0.15s;" onmouseover="this.style.opacity='0.7'" onmouseout="this.style.opacity='1'">
+        <div style="display:flex;justify-content:space-between;align-items:center;gap:8px;">
+          <span style="font-size:13px;color:var(--text-primary);font-weight:500;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${escapeHtml(a.name)}</span>
+          <span style="font-family:'Fira Code',monospace;font-size:14px;font-weight:700;color:${riskColor(a.risk_score)};flex-shrink:0;">${Math.round(a.risk_score)}</span>
+        </div>
+        ${repo ? `<div style="font-size:11px;color:var(--text-tertiary);font-family:'Fira Code',monospace;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${escapeHtml(repo)}</div>` : ''}
+      </a>`;
+    }).join('');
   } catch {}
 }
 
@@ -310,8 +316,15 @@ async function loadTopVuln() {
     const res = await fetch('/api/v1/reports/top-vulnerabilities?limit=200');
     if (!res.ok) return;
     const data = await res.json();
-    const items = data.items || [];
-    if (!items.length) return;
+    const allItems = data.items || [];
+    if (!allItems.length) return;
+    // Restrict to CVEs only
+    const items = allItems.filter(item => /^CVE-\d{4}-\d+/i.test(item.identifier));
+    if (!items.length) {
+      const container = document.getElementById('mc-top-vuln');
+      if (container) container.innerHTML = `<div style="font-size:13px;color:var(--text-tertiary);">No CVEs detected</div>`;
+      return;
+    }
     items.sort((a, b) => b.total_occurrences - a.total_occurrences);
     const v = items[0];
     const isCve = /^CVE-\d{4}-\d+/i.test(v.identifier);
@@ -344,16 +357,18 @@ async function loadTrendMiniChart() {
     if (!canvas) return;
     if (window._mcTrendChart) window._mcTrendChart.destroy();
     const isDark = document.documentElement.getAttribute('data-theme') !== 'light';
+    const tickColor = isDark ? 'rgba(148,163,184,0.55)' : 'rgba(71,85,105,0.65)';
+    const gridColor = isDark ? 'rgba(148,163,184,0.07)' : 'rgba(71,85,105,0.07)';
     window._mcTrendChart = new Chart(canvas.getContext('2d'), {
       type: 'line',
       data: {
         labels: points.map(p => p.date),
         datasets: [{
           data: values,
-          borderColor: isDark ? '#00e5ff' : '#0ea5e9',
+          borderColor: '#10b981',
           borderWidth: 2,
           fill: true,
-          backgroundColor: isDark ? 'rgba(0,229,255,0.08)' : 'rgba(14,165,233,0.08)',
+          backgroundColor: 'rgba(16,185,129,0.08)',
           pointRadius: 0,
           tension: 0.4
         }]
@@ -362,7 +377,31 @@ async function loadTrendMiniChart() {
         responsive: true,
         maintainAspectRatio: false,
         plugins: { legend: { display: false }, tooltip: { enabled: false } },
-        scales: { x: { display: false }, y: { display: false } },
+        scales: {
+          x: {
+            display: true,
+            ticks: {
+              maxTicksLimit: 5,
+              maxRotation: 0,
+              color: tickColor,
+              font: { size: 10 },
+              callback: function(value) {
+                const label = this.getLabelForValue(value);
+                if (!label) return '';
+                const d = new Date(label + 'T00:00:00');
+                return `${d.getMonth()+1}/${d.getDate()}`;
+              }
+            },
+            grid: { display: false },
+            border: { display: false }
+          },
+          y: {
+            display: true,
+            ticks: { maxTicksLimit: 3, color: tickColor, font: { size: 10 } },
+            grid: { color: gridColor },
+            border: { display: false }
+          }
+        },
         animation: { duration: 600 }
       }
     });
@@ -404,12 +443,13 @@ async function loadGrouped() {
       const rawIdent = v.identifier || '—';
       const isCve = /^CVE-\d{4}-\d+/i.test(rawIdent);
 
+      const _htitle = humanizeTitle(v.title || 'Unknown');
       const primaryHtml = isCve
         ? `<div class="cve-headline" style="white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${eh(rawIdent)}</div>`
-        : `<div style="font-size:14px;font-weight:600;color:var(--text-primary);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${eh((v.title||'Unknown').slice(0,65))}${(v.title||'').length>65?'…':''}</div>`;
+        : `<div style="font-size:14px;font-weight:600;color:var(--text-primary);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${eh(_htitle.slice(0,65))}${_htitle.length>65?'…':''}</div>`;
 
       const secondaryHtml = isCve
-        ? `<div style="font-size:12px;color:var(--text-tertiary);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;margin-top:2px;">${eh((v.title||'').slice(0,65))}${(v.title||'').length>65?'…':''}</div>`
+        ? `<div style="font-size:12px;color:var(--text-tertiary);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;margin-top:2px;">${eh(humanizeTitle(v.title||'').slice(0,65))}${(v.title||'').length>65?'…':''}</div>`
         : `<div style="font-size:12px;color:var(--text-tertiary);font-family:'Fira Code',monospace;margin-top:2px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${eh(rawIdent)}</div>`;
 
       const fix = v.fix_available
@@ -486,11 +526,13 @@ function fixBadge(f){
 
 function findingTitleCell(f) {
   const eh = escapeHtml;
+  const ht = humanizeTitle(f.title || '');
   if (f.cve_id) {
     return `<div class="cve-headline" style="white-space:nowrap;overflow:hidden;text-overflow:ellipsis;" title="${eh(f.cve_id)}">${eh(f.cve_id)}</div>
-            <div style="font-size:12px;color:var(--text-tertiary);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;margin-top:2px;" title="${eh(f.title||'')}">${eh((f.title||'').slice(0,60))}${(f.title||'').length>60?'…':''}</div>`;
+            <div style="font-size:12px;color:var(--text-tertiary);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;margin-top:2px;" title="${eh(ht)}">${eh(ht.slice(0,60))}${ht.length>60?'…':''}</div>`;
   }
-  return `<div style="font-size:15px;font-weight:600;color:var(--text-primary);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;" title="${eh(f.title||'')}">${eh((f.title||'Unknown').slice(0,60))}${(f.title||'').length>60?'…':''}</div>`;
+  const htFull = humanizeTitle(f.title || 'Unknown');
+  return `<div style="font-size:15px;font-weight:600;color:var(--text-primary);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;" title="${eh(htFull)}">${eh(htFull.slice(0,60))}${htFull.length>60?'…':''}</div>`;
 }
 
 function timeAgo(dateStr) {
@@ -747,7 +789,7 @@ function renderPanel(f) {
       </div>` : ''}
       <div>
         <div style="font-size:13px;font-weight:600;color:var(--text-tertiary);text-transform:uppercase;letter-spacing:1px;margin-bottom:6px;">Title</div>
-        <div style="font-size:16px;font-weight:600;color:var(--text-primary);line-height:1.4;">${eh(f.title)||'—'}</div>
+        <div style="font-size:16px;font-weight:600;color:var(--text-primary);line-height:1.4;">${eh(humanizeTitle(f.title||''))||'—'}</div>
       </div>
       ${f.description ? `
       <div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="/static/css/theme.css">
   <script src="/static/js/chart.min.js"></script>
   <script src="/static/js/lucide.min.js"></script>
+  <script src="/static/js/snitch-utils.js"></script>
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
 
@@ -876,7 +877,8 @@ function renderTopVulns(items) {
     return;
   }
   el.innerHTML = items.map(v => {
-    const title = escapeHtml((v.title||'Unknown').slice(0, 52)) + ((v.title||'').length > 52 ? '…' : '');
+    const _ht = humanizeTitle(v.title||'Unknown');
+    const title = escapeHtml(_ht.slice(0, 52)) + (_ht.length > 52 ? '…' : '');
     const rawIdent = v.identifier || v.cve_id || v.rule_id || '—';
     const ident = escapeHtml(rawIdent);
     const dot = severityDot(v.severity);

--- a/frontend/reports.html
+++ b/frontend/reports.html
@@ -10,6 +10,7 @@
   <link rel="stylesheet" href="/static/css/theme.css">
   <script src="/static/js/chart.min.js"></script>
   <script src="/static/js/lucide.min.js"></script>
+  <script src="/static/js/snitch-utils.js"></script>
   <style>
     * { box-sizing: border-box; }
     @keyframes slideInRight { from{transform:translateX(100px);opacity:0} to{transform:translateX(0);opacity:1} }
@@ -470,7 +471,7 @@ function renderTopVulns(items){
     <tr class="table-row" style="border-bottom:1px solid rgba(0,229,255,0.06);cursor:pointer;" onclick="window.location.href='${href}'">
       <td style="padding:12px;text-align:center;font-size:15px;font-weight:600;color:var(--text-tertiary);">${i+1}</td>
       <td style="padding:12px;width:45%;max-width:480px;">
-        <div style="font-size:15px;color:#e2e8f0;font-weight:500;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;" title="${escapeHtml(v.title||'')}">${escapeHtml((v.title||'Unknown vulnerability').slice(0,100))}${(v.title||'').length>100?'…':''}</div>
+        <div style="font-size:15px;color:#e2e8f0;font-weight:500;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;" title="${escapeHtml(humanizeTitle(v.title||''))}">${escapeHtml(humanizeTitle(v.title||'Unknown vulnerability').slice(0,100))}${humanizeTitle(v.title||'').length>100?'…':''}</div>
         ${v.identifier&&v.identifier!==v.title?`<div style="font-size:12px;color:var(--text-tertiary);font-family:'Fira Code',monospace;margin-top:2px;">${escapeHtml(v.identifier)}</div>`:''}
       </td>
       <td style="padding:12px;">${typeBadge(v.finding_type||v.scanner_type||v.type)}</td>

--- a/frontend/static/js/snitch-utils.js
+++ b/frontend/static/js/snitch-utils.js
@@ -1,0 +1,21 @@
+(function () {
+  const _LANG = { py: 'Python', js: 'JavaScript', ts: 'TypeScript', go: 'Go', java: 'Java', rb: 'Ruby', cs: 'C#', cpp: 'C++', rs: 'Rust', php: 'PHP' };
+  const _ACRONYM = { sql: 'SQL', xss: 'XSS', csrf: 'CSRF', ssrf: 'SSRF', rce: 'RCE', lfi: 'LFI', xxe: 'XXE', iac: 'IaC', api: 'API', aws: 'AWS', url: 'URL', ssh: 'SSH', tls: 'TLS', ssl: 'SSL', xml: 'XML', html: 'HTML', http: 'HTTP', idor: 'IDOR', ssti: 'SSTI', cmd: 'Command', cve: 'CVE' };
+  const _STRIP = new Set(['security', 'semgrep', 'checkov', 'gitleaks', 'trivy', 'grype', 'misc', 'rules', 'rule', 'check', 'checks', 'audit', 'detect', 'detection']);
+
+  // Convert a dotted/hyphenated rule ID like "dockerfile.security.missing-user.missing-user"
+  // into a readable title like "Dockerfile Missing User".
+  // Only transforms strings that look like rule IDs (contain dots/slashes, or are all-lowercase).
+  // Strings with spaces or mixed-case camelCase are returned unchanged.
+  window.humanizeTitle = function (raw) {
+    if (!raw || raw.includes(' ')) return raw;
+    // Skip if no dots/slashes and not all-lowercase (already a readable mixed-case title)
+    if (!raw.includes('.') && !raw.includes('/') && raw !== raw.toLowerCase()) return raw;
+    const parts = raw.toLowerCase().split(/[.\-_/]+/).filter(Boolean);
+    const seen = new Set();
+    const unique = parts.filter(p => { if (seen.has(p)) return false; seen.add(p); return true; });
+    const filtered = unique.filter(p => !_STRIP.has(p));
+    const words = filtered.map(p => _LANG[p] || _ACRONYM[p] || (p.charAt(0).toUpperCase() + p.slice(1)));
+    return words.length > 0 ? words.join(' ') : raw;
+  };
+})();


### PR DESCRIPTION
## Summary

- **CVE-first identifiers**: CVE IDs are now the bold primary headline (Fira Code monospace, accent blue) in both the grouped view and individual findings list; the human-readable title drops to secondary muted text beneath. Non-CVE findings (SAST rules, secrets, IaC) are unchanged — title remains primary, rule ID is secondary.
- **CVE Affected Repos panel**: Clicking a CVE row in the grouped view now opens a new slide-in panel (z-index 201) showing the CVE ID large, severity badge, CVSS score, and a live list of every affected repository as clickable links to `/app-detail.html`. Non-CVE rows still navigate to the filtered all-findings view.
- **Finding detail panel upgrade**: When a finding has a `cve_id`, a styled CVE hero block (large ID + CVSS, bordered box) appears at the top of the panel before the title — the old buried CVE grid cell is removed.
- **Data-attribute event delegation**: Grouped table rows use `data-identifier`, `data-title`, `data-severity`, `data-is-cve`, `data-cvss` attributes with a single delegated click listener — avoids `JSON.stringify` inside `onclick=""` which breaks HTML attribute parsing for strings containing double quotes.

## Test plan

- [ ] Grouped view: CVE rows show CVE ID as bold cyan headline, title as muted secondary
- [ ] Grouped view: non-CVE rows (SAST/secrets/IaC) unchanged — title primary, rule ID secondary
- [ ] Click a CVE row → CVE panel slides in with large CVE ID, severity, affected repo links
- [ ] Click an affected repo link → navigates to `/app-detail.html?id=...`
- [ ] Click "View all findings →" in CVE panel → switches to filtered individual view
- [ ] Click a non-CVE row → switches to filtered all-findings view as before
- [ ] Individual findings view: CVE findings show CVE ID as primary, title secondary
- [ ] Finding detail panel: CVE findings show hero block at top with CVE ID + CVSS
- [ ] Escape key closes either open panel
- [ ] Light mode: CVE IDs render in `#0ea5e9`, panel has white background

🤖 Generated with [Claude Code](https://claude.com/claude-code)